### PR TITLE
fix bug where clicking delete on frame on server frontend was causing…

### DIFF
--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -858,14 +858,8 @@ realityServer.gotClick = function (event) {
     var buttonClassList = thisEventObject.classList;
     var objectKey = thisEventObject.getAttribute("objectid");
     var frameKey = thisEventObject.getAttribute("frameid");
-
-    let thisObject = {};
-
-    if (frameKey) {
-        thisObject = realityServer.objects[objectKey].frames[frameKey];
-    } else {
-        thisObject = realityServer.objects[objectKey];
-    }
+    
+    let thisObject = realityServer.objects[objectKey];
 
     if (buttonClassList.contains("download")) {
         window.location.href= "/object/" + thisObject.name + "/zipBackup/";


### PR DESCRIPTION
… an error where it expected thisObject to be an object but it was pointing to a frame.

Thought I already pushed this change but it must have gotten lost amidst the branches late last week.

not sure why thisObject was sometimes referring to a frame when it was always treated as an object.. fixing it doesn't seem to cause any other bugs