### PR TITLE
Set tool to interface tools path

### DIFF
--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -328,6 +328,64 @@ exports.triggerUDPCallbacks = function(msgContent) {
     });
 };
 
+exports.clearTool = function(objectName, frameName){
+    var objectID = utilities.getObjectIdFromTarget(objectName, objectsPath);
+    console.log('remove set tool');
+
+    var frameUuid = objectID + frameName;
+
+    if (!_.isUndefined(objectID) && !_.isNull(objectID)) {
+        if (objects.hasOwnProperty(objectID)) {
+            if (objects[objectID].frames.hasOwnProperty(frameUuid)) {
+                if (objects[objectID].frames[frameUuid].hasOwnProperty('tool')) {
+                    delete objects[objectID].frames[frameUuid].tool;
+                }
+            }
+        }
+    }
+}
+
+exports.setTool = function(objectName, frameName, tool, dirName){
+  
+    var objectID = utilities.getObjectIdFromTarget(objectName, objectsPath);
+    console.log('set new tool: ', tool);
+
+    var frameUuid = objectID + frameName;
+
+    if (!_.isUndefined(objectID) && !_.isNull(objectID)) {
+        if (objects.hasOwnProperty(objectID)) {
+
+            if (dirName) {
+
+                var addonName = '';
+                var interfaceName = '';
+
+                var dirArray = dirName.split('/');
+                var dirLength = dirArray.length;
+
+                if (dirArray[dirLength - 2] === 'interfaces') {
+                    addonName = dirArray[dirLength - 3];
+                    interfaceName = dirArray[dirLength - 1];
+                } else {
+                    var dirArray = dirName.split('\\');
+                    var dirLength = dirArray.length;
+
+                    if (dirArray[dirLength - 2] === 'interfaces') {
+                        addonName = dirArray[dirLength - 3];
+                        interfaceName = dirArray[dirLength - 1];
+
+                    }
+                }
+                if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
+                    objects[objectID].frames[frameUuid] = new Frame();
+                }
+                //define the tool that is used with this frame
+                objects[objectID].frames[frameUuid].tool = {addon: addonName, interface: interfaceName, tool: tool};
+            }
+        }
+    }
+}
+
 /**
  * @desc addIO() a new IO point to the specified RealityInterface
  * @param {string} objectName The name of the RealityInterface

--- a/server.js
+++ b/server.js
@@ -1042,6 +1042,7 @@ function objectWebServer() {
     // webServer.use('/frames', express.static(__dirname + '/libraries/frames/'));
 
     webServer.use('/frames/:frameName', function (req, res, next) {
+      
         var urlArray = req.originalUrl.split('/');
         const frameLibPath = frameFolderLoader.resolvePath(req.params.frameName);
         console.log('frame load', req.params.frameName, frameLibPath, req.originalUrl);
@@ -1111,11 +1112,37 @@ function objectWebServer() {
     });
 
     webServer.use('/obj', function (req, res, next) {
-
+        
+       
+     
         var urlArray = req.originalUrl.split('/');
         urlArray.splice(0, 1);
         urlArray.splice(0, 1);
         if (urlArray[1] === 'frames') {
+            var objectKey = utilities.readObject(objectLookup, urlArray[0]);
+            var frameKey = utilities.readObject(objectLookup, urlArray[0]) + urlArray[1];
+            
+            var addonName = '';
+            var interfaceName = '';
+            var toolName = '';
+
+            var thisFrame = getFrame(objectKey, frameKey);
+            
+            if(thisFrame !== null){
+                if(thisFrame.tools)
+                
+                
+                
+            }
+            
+            console.log(__dirname+'/addons/'+addonName+'/interfaces/'+interfaceName+'/tools/'+toolname);
+            console.log("###################################################################is this what I get?",urlArray);
+         
+            
+            if(objects[objectKey].frames[frameKey].tools){
+                
+            }
+            
             urlArray.splice(1, 1);
         }
 


### PR DESCRIPTION
new API for hardware Interfaces
  server.setTool("object", "frame", "toolfolderName", __dirname);
  server.clearTool("object", "frame");

Use this API if you want to deliver a default local tool with your interface.
Save your default tool in interfaces/interfaceName/tools/toolName/
