### PR TITLE
Auto-initialize world objects without targets when created on frontend

### DIFF
--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -153,6 +153,11 @@ exports.printFolder = function (objects, objectsPath, debug, objectInterfaceName
             newObject[thisObjectKey].targetName = objectKey + utilities.uuidTime(); // generates a suggested uuid for the target
         }
 
+        // world objects are always initialized true regardless of target data
+        if (newObject[thisObjectKey].isWorldObject) {
+            newObject[thisObjectKey].initialized = true;
+        }
+
         newObject[thisObjectKey].targetsExist = {
             datExists: datExists,
             xmlExists: xmlExists,

--- a/libraries/webInterface/gui/index.html
+++ b/libraries/webInterface/gui/index.html
@@ -123,7 +123,7 @@
     <div class="">
     <div class="object group adjustedMargin">
         <div class="item half button noBorder noBackground triangle"></div>
-        <div class='name item button white nameWidthMedium'>Name
+        <div class='name item button white nameWidthMedium' style="width: 181px">Name
         </div><div class='item space hidden'>
         </div><div class='textfield zone item button white one textcursor' contenteditable
                onclick='if(this.innerText === "Zone") {this.innerText=""; this.style.fonts = "12pt"}'>Zone
@@ -151,7 +151,7 @@
     <div class="worldObject group adjustedMargin">
         <div>
             <div class="item half button noBorder noBackground triangle hidden"></div>
-            <div class='name item button white nameWidthMedium'>Name</div>
+            <div class='name item button white nameWidthMedium' style="width: 181px">Name</div>
             <div class='item hidden space smallSpace'></div>
             <div class='textfield zone item button white one textcursor' contenteditable onclick='if(this.innerText === "Zone") {this.innerText=""; this.style.fonts = "12pt"}'>Zone</div>
             <div class='item hidden space smallSpace'></div>

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -1472,16 +1472,16 @@ realityServer.gotClick = function (event) {
                                         });
                                     }, 100);
                                 }
-                            }, 'name='+msgContent.name+'&width='+defaultSize+'&height='+defaultSize);
+                            }, 'name=' + msgContent.name + '&width=' + defaultSize + '&height=' + defaultSize);
 
                         } catch (e) {
-                            console.warn('json parse error for (action=new&name=\''+objectName+'\') response: ' + state);
+                            console.warn('json parse error for (action=new&name=\'' + objectName + '\') response: ' + state);
                         }
                     }
 
                     // realityServer.objects = realityServer.sortObject(realityServer.objects);
                     realityServer.update();
-                }, 'action=new&name='+objectName+'&isWorld='+shouldAddWorldObject);
+                }, 'action=new&name=' + objectName + '&isWorld=' + shouldAddWorldObject);
             }
         }
     }

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -309,30 +309,30 @@ realityServer.updateManageObjects = function(thisItem2) {
                         window.location.href = '/object/' + realityServer.objects[objectKey].name + '/zipBackup/';
                     });
 
-                    // make Add Target button turn green when fully initialized
+                    // world objects with targets should have a green "Edit Origin" button when fully initialized
                     if (thisObject.targetsExist.datExists || thisObject.targetsExist.jpgExists) {
                         realityServer.switchClass(thisObject.dom.querySelector('.target'), 'yellow', 'green');
                         realityServer.switchClass(thisObject.dom.querySelector('.target'), 'targetWidthMedium', 'one');
                         thisObject.dom.querySelector('.target').innerText = 'Edit Origin';
 
+                        // only add the icon if it exists
                         if (thisObject.targetsExist.jpgExists) {
                             let ipAddress = realityServer.states.ipAdress.interfaces[realityServer.states.ipAdress.activeInterface];
                             thisObject.dom.querySelector('.objectTargetIcon').src = 'http://' + ipAddress + ':' + realityServer.states.serverPort + '/obj/' + thisObject.name + '/target/target.jpg';
                         }
 
                     } else {
-                        function updateTargetButtonAfterDelay(thisObjectKey) {
-                            setTimeout(function() {
-                                let thisObjectElement = document.getElementById('object' + thisObjectKey)
-                                if (thisObjectElement) {
-                                    console.log('remove objectIcon for ' + thisObjectKey);
+                        // world objects without targets should have an "Add Origin Target" button instead
+                        setTimeout(function(thisObjectKey) {
+                            let thisObjectElement = document.getElementById('object' + thisObjectKey);
+                            if (thisObjectElement) {
+                                if (thisObjectElement.querySelector('.objectIcon')) {
                                     thisObjectElement.querySelector('.objectIcon').remove();
-                                    realityServer.switchClass(thisObjectElement.querySelector('.target'), 'one', 'targetWidthMedium');
-                                    thisObjectElement.querySelector('.target').innerText = 'Add Origin Target';
                                 }
-                            }, 10);
-                        }
-                        updateTargetButtonAfterDelay(objectKey); // interferes with other layout if happens immediately
+                                realityServer.switchClass(thisObjectElement.querySelector('.target'), 'one', 'targetWidthMedium');
+                                thisObjectElement.querySelector('.target').innerText = 'Add Origin Target';
+                            }
+                        }, 10, objectKey); // interferes with other layout in Safari if happens immediately
                     }
 
                     // make Frame Sharing button turn green or yellow depending on state

--- a/server.js
+++ b/server.js
@@ -3322,7 +3322,7 @@ function objectWebServer() {
             try {
                 getObject(objectID).deactivated = true;
                 utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
-                res.status(200).send("ok");
+                res.status(200).send('ok');
             } catch (e) {
                 res.status(404).json({success: false, error: 'cannot find object with ID' + objectID}).end();
             }
@@ -3333,7 +3333,7 @@ function objectWebServer() {
             try {
                 getObject(objectID).deactivated = false;
                 utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
-                res.status(200).send("ok");
+                res.status(200).send('ok');
             } catch (e) {
                 res.status(404).json({success: false, error: 'cannot find object with ID' + objectID}).end();
             }

--- a/server.js
+++ b/server.js
@@ -3424,13 +3424,13 @@ function objectWebServer() {
                 '   </Tracking>\n' +
                 '   </ARConfig>';
 
-            let targetDir = path.join(objectsPath, objectName, identityFolderName, "target");
+            let targetDir = path.join(objectsPath, objectName, identityFolderName, 'target');
             if (!fs.existsSync(targetDir)) {
                 fs.mkdirSync(targetDir);
                 console.log('created directory: ' + targetDir);
             }
 
-            var xmlOutFile = path.join(targetDir, "target.xml");
+            var xmlOutFile = path.join(targetDir, 'target.xml');
 
             fs.writeFile(xmlOutFile, documentcreate, function (err) {
                 if (err) {


### PR DESCRIPTION
Instead of making them deactivated until you add a DAT/JPG target. Slight updates to UI to make it clearer that world objects are enabled by default but you can add an origin target to them:

<img width="957" alt="Screen Shot 2020-03-11 at 4 36 32 PM" src="https://user-images.githubusercontent.com/32580292/76475931-d40d1600-63d6-11ea-8caa-ad0dc2c6fa94.png">
