### PR TITLE
Update web dashboard frames->tools

### DIFF
--- a/libraries/webInterface/gui/index.css
+++ b/libraries/webInterface/gui/index.css
@@ -38,6 +38,7 @@ body {
 
 #logo {
   width: 400pt;
+  cursor: pointer;
 }
 
 #subtitle {

--- a/libraries/webInterface/gui/index.html
+++ b/libraries/webInterface/gui/index.html
@@ -413,15 +413,8 @@
 
 <template id="startFrames">
     <div class="startFrames">
-        <div id="setFramesPath" class='button yellow three inactive'>
-            Choose Spatial Tools Directory
-<!--            <input type="file" id="pathSelectionInput" webkitdirectory directory multiple/>-->
-        </div>
-        <div class='hidden space smallSpace'></div>
-        <div id="framesPath" class='button white four inactive ' style="overflow: hidden">
-         
-            <!--            <input type="file" id="pathSelectionInput" webkitdirectory directory multiple/>-->
-        </div>
+    <!-- This used to contain the realityframes path. In the future it can contain info about the
+    addons that are being used to source the tools-->
     </div>
     <div id="globalFramesDescription"></div>
 </template>

--- a/libraries/webInterface/gui/index.html
+++ b/libraries/webInterface/gui/index.html
@@ -47,38 +47,42 @@
             <div class='upload button blue two inactive'>Upload Object File</div>
         </div>
         <div id="objectDescription"></div>
-<!--        <div class="serverDescription" id="mainDescription">-->
-<!--            Welcome to the Reality Server web interface. Here in the Object Configuration tab, you can create new objects to be associated with AR targets, add custom HTML content to those targets, and manage which objects will be active and viewable in this network.-->
-<!--        </div>-->
-<!--        <div class="serverDescription" id="createObjectDescription">-->
-<!--            To get started, click the Add Object button and give your new Reality Object a name. It must have a unique name compared to all the other Reality Objects on this server.-->
-<!--        </div>-->
-<!--        <div class="serverDescription" id="addTargetDescription">-->
-<!--            Now you need to add target files to your object. Click on Add Target.-->
-<!--        </div>-->
     </div>
 </template>
 
 <template id="objectTutorial">
     <div class="tutorial">
         <div class="serverDescription" id="mainDescription">
-            Welcome to the Reality Server web interface. Here in the Object Configuration tab, you can create new objects to be associated with AR targets, add custom HTML content to those targets, and manage which objects will be active and viewable in this network.
+            Welcome to the Vuforia Spatial Edge Server web interface. Here in the Object
+            Configuration tab, you can create new objects to be associated with AR targets, add
+            custom HTML content to those targets, and manage which objects will be active and
+            viewable to clients in this network.
         </div>
         <div class="serverDescription" id="createObjectDescription">
-            To get started, click the Add Object button and give your new Reality Object a name. It must have a unique name compared to all the other Reality Objects on this server.
+            To get started, click the Add Object button and give your new Reality Object a name.
+            It must have a unique name compared to all the other Reality Objects on this server.
         </div>
         <div class="serverDescription" id="addTargetDescription">
-            Now you need to add an Image or Object target to your object. Click on Add Target. To use an image target, drag and drop a .jpg image file onto the drop zone. To use an object target, drag and drop the .dat file generated from the Vuforia Developer portal.
+            Now you need to add an Image or Object target to your object. Click on Add Target. To
+            use an image target, drag and drop a .jpg image file onto the drop zone. To use an
+            object target, drag and drop the .dat file generated from the Vuforia Developer
+            portal.
         </div>
         <div class="serverDescription" id="addFrameDescription">
-            Your object is now active, and should be visible to a Reality Editor app connected to the same WiFi network, as long as the network supports UDP broadcasting. But there is currently no AR content associated with your object. <br>
+            Your object is now active, and should be visible to any Vuforia Spatial Toolbox apps
+            connected to the same WiFi network, as long as the network supports UDP broadcasting.
+            But there is currently no AR content associated with your object.<br>
             <br>
-            To add some placeholder content, click on Add Frame, and give your frame a name.
+            To add some placeholder content, click on Add Tool, and give your tool a name.
         </div>
         <div class="serverDescription" id="frameAddedDescription">
-            Now, when you view the specified image or object target, you should see the default UI appear. You can edit this content by editing the index.html file for this frame, in your realityobjects directory.<br>
+            Now, when you view the specified image or object target, you should see the default tool
+            UI appear (a blue square). You can edit this content by editing the index.html file for
+            this tool, in your realityobjects directory
+            (~/Documents/realityobjects/[object-name]/[tool-name]/index.html).<br>
             <br>
-            To toggle additional help messages in the future, click the Show/Hide Help button in the upper right corner.
+            To toggle additional help messages in the future, click the Show/Hide Help button in
+            the upper right corner.
         </div>
     </div>
 </template>
@@ -86,13 +90,22 @@
 <template id="globalFramesTutorial">
     <div class="tutorial" style="margin-bottom: 21px">
         <div class="serverDescription" id="framesDescription">
-            The Spatial Tools tab lets you see all the reusable frames that you will be able to drop into your environment using any Reality Editor that is connected to the same WiFi network as this server. Just tap on the Pocket button in the app and you will see all of these available frames.
+            The Spatial Tools tab lets you see all the reusable (global) tools that you will be able
+            to drop into your environment using any Vuforia Spatial Toolbox app that is connected
+            to the same WiFi network as this server. Just tap on the Pocket button in the app
+            and you will see all of these available tools.
         </div>
         <div class="serverDescription" id="noFramesDescription">
-            This list of frames is loaded from your ~/Documents/realityframes directory, which should be automatically generated at the path displayed above. You currently don't have any frames correctly set up in that directory. To download the default set of Spatial Tools, follow our installation instructions.
+            This list of tools is loaded from your edge server's addons directory. You currently
+            don't have any tools correctly set up in any addons. To download the default set of
+            Spatial Tools, follow our installation instructions to add the
+            vuforia-spatial-core-addon to the addons directory.
         </div>
         <div class="serverDescription" id="foundFramesDescription">
-            To preview the application content in this web browser, just click on the Content button. The download button will download a backup of this frame. The On/Off button can be used to hide individual frames from being shown in the Pocket of Reality Editors in this network.
+            To preview the content of any tool in this web browser, just click on the Content
+            button. The download button will download a backup of the tool. The On/Off button
+            can be used to hide individual tools from being shown in the Pocket of clients in
+            this network.
         </div>
     </div>
 </template>
@@ -100,9 +113,13 @@
 <template id="hardwareInterfacesTutorial">
     <div class="tutorial" style="margin-bottom: 21px">
         <div class="serverDescription" id="hardwareDescription">
-            The Hardware Interfaces tab lets you manage the adaptors that this server uses to communicate with external hardware systems. Configurable hardware interfaces can be turned on and off here. Hardware Interfaces with a gear icon can be clicked on to further configure their settings.<br>
+            The Hardware Interfaces tab lets you manage the adaptors that this server uses to
+            communicate with external hardware systems. Configurable hardware interfaces can be
+            turned on and off here. Hardware Interfaces with a gear icon can be clicked on to
+            further configure their settings.<br>
             <br>
-            You must restart your server after making any changes for those changes to take effect.
+            You should restart your server after making any changes to ensure that those changes
+            have taken effect.
         </div>
     </div>
 </template>
@@ -133,7 +150,7 @@
         </div>
         <div class='objectIcon item space noBackground half'><img class="objectTargetIcon"></div>
         <div class='objectIconSpace item hidden space' style="width: 2px"></div>
-        <div class='addFrame item button blue one'>Add Frame
+        <div class='addFrame item button blue one'>Add Tool
         </div><div class='item space hidden'>
         </div><div class='visualization item button blue one'>Screen
         </div><div class='item space hidden'>
@@ -159,7 +176,7 @@
 <!--            <div class='item hidden space smallSpace spaceAfterTarget'></div>-->
             <div class='objectIcon item space noBackground half'><img class="objectTargetIcon"></div>
             <div class='objectIconSpace item hidden space' style="width: 2px"></div>
-            <div class='sharing item button yellow two'>Frame Sharing Off</div>
+            <div class='sharing item button yellow two'>Tool Sharing Off</div>
             <div class='item hidden space smallSpace'></div>
             <div class='remove item button red half clickAble'>X</div>
             <div class='item hidden space smallSpace'></div>

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -553,12 +553,6 @@ realityServer.updateManageFrames = function() {
 
     this.getDomContents().appendChild(this.templates['startFrames'].content.cloneNode(true));
 
-    // this.getDomContents().querySelector('#pathSelectionInput').addEventListener('change', function(e) {
-    //     console.log(e);
-    // });
-
-    this.getDomContents().querySelector('#framesPath').innerText = realityServer.states.globalFramesPath || '';
-
     /////// Tutorial ///////
     document.getElementById('globalFramesDescription').appendChild(this.templates['globalFramesTutorial'].content.cloneNode(true));
 

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -61,6 +61,11 @@ realityServer.initialize = function () {
         }
     }
 
+    // clicking on header should refresh
+    document.getElementById('logo').addEventListener('click', function() {
+        window.location.reload();
+    });
+
     document.getElementById('subtitle').innerText = 'Version: ' + realityServer.states.version + ' - Server IP: ' +
         realityServer.states.ipAdress.interfaces[realityServer.states.ipAdress.activeInterface] + ':' + realityServer.states.serverPort;
 

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -338,11 +338,11 @@ realityServer.updateManageObjects = function(thisItem2) {
                     // make Frame Sharing button turn green or yellow depending on state
                     if (thisObject.sharingEnabled) {
                         realityServer.switchClass(thisObject.dom.querySelector('.sharing'), 'yellow', 'green');
-                        thisObject.dom.querySelector('.sharing').innerText = 'Frame Sharing On';
+                        thisObject.dom.querySelector('.sharing').innerText = 'Tool Sharing On';
 
                     } else {
                         realityServer.switchClass(thisObject.dom.querySelector('.sharing'), 'green', 'yellow');
-                        thisObject.dom.querySelector('.sharing').innerText = 'Frame Sharing Off';
+                        thisObject.dom.querySelector('.sharing').innerText = 'Tool Sharing Off';
                     }
 
                     addEnabledToggle(thisObject.dom.querySelector('.active'), objectKey, thisObject); // create inside closure so interfaceInfo doesn't change after definition

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -61,7 +61,7 @@ realityServer.initialize = function () {
         }
     }
 
-    // clicking on header should refresh
+    // clicking on header refreshes -> goes back to objects tab
     document.getElementById('logo').addEventListener('click', function() {
         window.location.reload();
     });


### PR DESCRIPTION
Half of the references to Frames had already been switched to "tools". This just finishes the job, mostly by changing the "Add Frame" button to "Add Tool". Also updates tutorial text with new names, and clicking on the header brings you home.

Unfortunately, will need to update some existing tutorials that mention the "Add Frame" button, but I figure it's better to update this sooner rather than later.