### PR TITLE
adds /subscribe/interfaceSettings socket to config.html pages and..

### DIFF
--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -45,6 +45,7 @@ var frameAddedCallbacks = [];
 var resetCallbacks = [];
 var matrixStreamCallbacks = [];
 var udpMessageCallbacks = [];
+var interfaceSettingsCallbacks = {};
 var screenPortMap = {};
 var _this = this;
 
@@ -896,6 +897,22 @@ exports.advertiseConnection = function (object, frame, node, logic) {
         names: [object, node]
     }};
     actionCallback(message);
+};
+
+exports.addSettingsCallback = function(interfaceName, callback) {
+    if (typeof interfaceSettingsCallbacks[interfaceName] === 'undefined') {
+        interfaceSettingsCallbacks[interfaceName] = [];
+    }
+    interfaceSettingsCallbacks[interfaceName].push(callback);
+};
+
+exports.pushSettingsToGui = function(interfaceName, currentSettings) {
+    console.log('pushSettingsToGui for ' + interfaceName);
+    if (typeof interfaceSettingsCallbacks[interfaceName] !== 'undefined') {
+        interfaceSettingsCallbacks[interfaceName].forEach(function(callback) {
+            callback(interfaceName, currentSettings);
+        });
+    }
 };
 
 exports.shutdown = function () {

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -899,6 +899,11 @@ exports.advertiseConnection = function (object, frame, node, logic) {
     actionCallback(message);
 };
 
+/**
+ * Used by the server to emit a socket message when settings change
+ * @param {string} interfaceName - exact name of the hardware interface
+ * @param {function} callback
+ */
 exports.addSettingsCallback = function(interfaceName, callback) {
     if (typeof interfaceSettingsCallbacks[interfaceName] === 'undefined') {
         interfaceSettingsCallbacks[interfaceName] = [];
@@ -906,6 +911,11 @@ exports.addSettingsCallback = function(interfaceName, callback) {
     interfaceSettingsCallbacks[interfaceName].push(callback);
 };
 
+/**
+ * Public API for hardware interfaces to trigger when they update any settings
+ * @param {string} interfaceName - exact name of the hardware interface
+ * @param {JSON} currentSettings - should be the exports.settings
+ */
 exports.pushSettingsToGui = function(interfaceName, currentSettings) {
     console.log('pushSettingsToGui for ' + interfaceName);
     if (typeof interfaceSettingsCallbacks[interfaceName] !== 'undefined') {

--- a/libraries/webInterface/gui/config.js
+++ b/libraries/webInterface/gui/config.js
@@ -1,3 +1,11 @@
+/**
+ * @fileOverview
+ * This is a library that should be included in hardware interface's config.html pages in order
+ * to automatically add a websocket to the page and give them access to teh InterfaceConfig
+ * APIs, which will allow them to subscribe to realtime updates to the settings from the
+ * hardware interface's index.js
+ */
+
 let socketIoScript = {};
 let socketIoRequest = {};
 
@@ -21,8 +29,8 @@ function loadScriptSync(url, requestObject, scriptObject) {
 loadScriptSync('../../socket.io/socket.io.js', socketIoRequest, socketIoScript);
 
 /**
- * This is used to allow the config.html pages for hardware interfaces to subscribe to new values
- * @param interfaceName
+ * This is used to allow the config.html pages for hardware interfaces to subscribe to new settings
+ * @param {string} interfaceName - exact name of the hardware interface
  * @constructor
  */
 function InterfaceConfig(interfaceName) { // eslint-disable-line no-unused-vars

--- a/libraries/webInterface/gui/config.js
+++ b/libraries/webInterface/gui/config.js
@@ -1,0 +1,51 @@
+let socketIoScript = {};
+let socketIoRequest = {};
+
+// Load socket.io.js synchronous so that it is available by the time the rest of the code is executed.
+function loadScriptSync(url, requestObject, scriptObject) {
+    requestObject = new XMLHttpRequest();
+    requestObject.open('GET', url, false);
+    requestObject.send();
+
+    // Only add script if fetch was successful
+    if (requestObject.status === 200) {
+        scriptObject = document.createElement('script');
+        scriptObject.type = 'text/javascript';
+        scriptObject.text = requestObject.responseText;
+        document.getElementsByTagName('head')[0].appendChild(scriptObject);
+    } else {
+        console.log('Error XMLHttpRequest HTTP status: ' + requestObject.status);
+    }
+}
+
+loadScriptSync('../../socket.io/socket.io.js', socketIoRequest, socketIoScript);
+
+/**
+ * This is used to allow the config.html pages for hardware interfaces to subscribe to new values
+ * @param interfaceName
+ * @constructor
+ */
+function InterfaceConfig(interfaceName) { // eslint-disable-line no-unused-vars
+    if (typeof io !== 'undefined') {
+        var _this = this;
+
+        this.ioObject = io.connect();
+
+        this.addSettingsUpdateListener = function (callback) {
+            console.log('added interfaceSettings socket listener');
+
+            _this.ioObject.emit('/subscribe/interfaceSettings', JSON.stringify({
+                interfaceName: interfaceName
+            }));
+
+            _this.ioObject.on('interfaceSettings', function (msg) {
+                var thisMsg = JSON.parse(msg);
+                callback(thisMsg);
+            });
+        };
+
+        console.log('socket.io is loaded');
+    } else {
+        console.warn('socket.io is not working. This is normal when you work offline.');
+    }
+}

--- a/server.js
+++ b/server.js
@@ -1097,8 +1097,6 @@ function objectWebServer() {
 
     });
 
-
-
     webServer.use('/logicNodeIcon', function (req, res) {
         var urlArray = req.originalUrl.split('/');
         console.log('logicNodeIcon urlArray', urlArray);
@@ -4480,7 +4478,6 @@ socketHandler.sendPublicDataToAllSubscribers = function(objectKey, frameKey, nod
     }
 };
 
-
 function socketServer() {
 
     io.on('connection', function (socket) {
@@ -4605,6 +4602,22 @@ function socketServer() {
                 block: msgContent.block,
                 publicData: publicData
             }));
+        });
+
+        socket.on('/subscribe/interfaceSettings', function (msg) {
+            console.log('recieved /subscribe/interfaceSettings');
+            let msgContent = JSON.parse(msg);
+            if (msgContent.interfaceName) {
+                console.log('/subscribe/interfaceSettings for ' + msgContent.interfaceName);
+                hardwareAPI.addSettingsCallback(msgContent.interfaceName, function(interfaceName, currentSettings) {
+                    if (io.sockets.connected[socket.id]) {
+                        io.sockets.connected[socket.id].emit('interfaceSettings', JSON.stringify({
+                            interfaceName: interfaceName,
+                            currentSettings: currentSettings
+                        }));
+                    }
+                });
+            }
         });
 
         socket.on('object', function (msg) {

--- a/server.js
+++ b/server.js
@@ -4604,6 +4604,10 @@ function socketServer() {
             }));
         });
 
+        /**
+         * A hardware interface's config.html makes use of this to subscribe to
+         * realtime settings updates from the hardware interface's index.js
+         */
         socket.on('/subscribe/interfaceSettings', function (msg) {
             console.log('recieved /subscribe/interfaceSettings');
             let msgContent = JSON.parse(msg);


### PR DESCRIPTION
.. pushSettingsToGui API to hardware interfaces

Allows the "Manage Hardware Interface" config.html page to subscribe to live updates of the settings, if the hardware interface updates any of the settings after it loads.

How to use:
In your hardware interface, if you update the exports.settings, call:
```
server.pushSettingsToGui('name of your hardware interface', exports.settings);
```

In your config.html, include config.js:
```
<script src="../libraries/gui/config.js"></script>
```
Then create an InterfaceConfig, and subscribe to settings:
```
let interfaceConfig = new InterfaceConfig(realityServer.hardwareInterfaceName);
interfaceConfig.addSettingsUpdateListener(function(thisMsg) {
    let settingName = 'randomNumber';
    let settingValue = thisMsg.currentSettings[settingName].value;
    console.log('new value for ' + settingName + ' is ' + settingValue);
});
```

Note: calling pushSettingsToGui doesn't actually write the exports.settings to the settings.json file on disk. The only way to write to that is from the web frontend. But this can be used to push temporary settings states to the frontend, such as whether the hardware connected successfully.