### PR TITLE
Further specify that node 6 is only supported for mobile devices

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -39,6 +39,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm install
     - run: npm run build --if-present
-    - run: npm run execution-test-only
+    - run: npm run test-node-six-mobile
       env:
         CI: true

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "minami": "^1.2.3"
   },
   "scripts": {
-    "test": "npm run lint && npm run execution-test-only",
-    "execution-test-only": "NODE_ENV=test node test.js",
+    "test": "npm run lint && NODE_ENV=test node test.js",
+    "test-node-six-mobile": "NODE_ENV=test FORCE_MOBILE=true node test.js",
     "lint": "eslint .",
     "generate-docs": "jsdoc -c .jsdoc.conf -r .",
     "start": "node server.js"

--- a/server.js
+++ b/server.js
@@ -54,7 +54,7 @@ require('module-alias/register');
 const _logger = require('./logger');
 
 const os = require('os');
-const isMobile = os.platform() === 'android' || os.platform() === 'ios';
+const isMobile = os.platform() === 'android' || os.platform() === 'ios' || process.env.FORCE_MOBILE;
 
 // These variables are used for global status, such as if the server sends debugging messages and if the developer
 // user interfaces should be accesable


### PR DESCRIPTION
Tests are currently failing because express-handlebars snuck in a change incompatible with node 6 but that doesn't impact us since we don't use express-handlebars on mobile