### PR TITLE
Frontend notifications

### DIFF
--- a/libraries/webInterface/css/notifications.css
+++ b/libraries/webInterface/css/notifications.css
@@ -1,0 +1,34 @@
+.notification {
+    position: relative;
+    left: 0;
+    top: 0;
+    width: 100vw;
+    height: 30px;
+    line-height: 30px;
+    text-align: center;
+    color: white;
+    background-color: rgba(34, 34, 34, 0.7);
+    border-bottom: 1px solid rgba(0,0,0,0.7);
+}
+
+.closeNotification {
+    position: absolute;
+    left: 5px;
+    top: 0;
+    width: 20px;
+    line-height: 30px;
+    height: 30px;
+    cursor: pointer;
+}
+
+.notificationError {
+    background-color: rgba(127, 0, 0, 0.7);
+}
+
+.notificationList {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100vw;
+    line-height: 30px;
+}

--- a/libraries/webInterface/gui/index.html
+++ b/libraries/webInterface/gui/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" initial-scale=0.1">
     <title>Vuforia Spatial Edge Server</title>
     <link rel="stylesheet" type="text/css" href="index.css?32">
+    <link rel="stylesheet" type="text/css" href="../css/notifications.css">
     <script src="resources/dropzone.js"></script>
 </head>
 <body>
@@ -472,6 +473,7 @@
     }; // the objects and states get injected from the server webFrontend.js
 </script>
 
+<script src="notifications.js"></script>
 <script src="index.js?33saasdd"></script>
 <script src="utilities.js"></script>
 

--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -1116,6 +1116,12 @@ realityServer.gotClick = function (event) {
                 }
 
             });
+
+            realityServer.myTargetDropzone.on('error', function(file, message) {
+                if (typeof message.error !== 'undefined') {
+                    showErrorNotification(message.error);
+                }
+            });
         } else {
             realityServer.dropZoneId = '';
             let removeNode = document.getElementById('targetDropZone' + objectKey);

--- a/libraries/webInterface/gui/notifications.js
+++ b/libraries/webInterface/gui/notifications.js
@@ -1,0 +1,149 @@
+/**
+ * @fileOverview
+ * Defines a Notification class and a NotificationList class for showing messages at the
+ * top of the screen that disappear after a set amount of time
+ *
+ * Only exports showErrorNotification and showMessageNotification
+ *
+ * Be sure to include styles defined in notifications.css
+ *
+ * Example usage:
+ *
+ * showErrorNotification('Incorrect file format');
+ * // shows a red message that disappears after default 5 seconds
+ *
+ * showErrorNotification('Incorrect file format', 10000);
+ * // disappears after 10 seconds
+ *
+ * showErrorNotification('Incorrect file format', -1);
+ * // never disappears until user clicks its X button
+ */
+
+(function(exports) {
+
+    const defaultTimeToLive = 5000; // 5 seconds
+    let notificationList = null; // it only makes sense to have at most 1 of these
+    // it gets created and added only if the show notification API is used
+
+    /**
+     * Show an error message on the top of the screen
+     * Hides when the user clicks its X button or after the timeToLive
+     * If timeToLive is omitted, defaults to 5 seconds
+     * If timeToLive is set to <= 0, never disappears until user clicks X
+     * @param {string} displayText
+     * @param {number?} timeToLive - in milliseconds
+     */
+    function showErrorNotification(displayText, timeToLive) {
+        addNotificationListIfNecessary();
+        notificationList.showErrorNotification(displayText, timeToLive);
+    }
+
+    /**
+     * Show a log message on the top of the screen
+     * Hides when the user clicks its X button or after the timeToLive
+     * If timeToLive is omitted, defaults to 5 seconds
+     * If timeToLive is set to <= 0, never disappears until user clicks X
+     * @param {string} displayText
+     * @param {number?} timeToLive - in milliseconds
+     */
+    function showMessageNotification(displayText, timeToLive) {
+        addNotificationListIfNecessary();
+        notificationList.showMessageNotification(displayText, timeToLive);
+    }
+
+    function Notification(messageText, type, onClose) {
+        this.messageText = messageText;
+        this.type = type;
+        this.onClose = onClose;
+        this.removalTimeout = null;
+
+        // construct the DOM element
+        this.domElement = this.buildNotificationElement();
+    }
+
+    Notification.prototype.buildNotificationElement = function() {
+        // add a container with the message
+        let element = document.createElement('div');
+        element.className = 'notification';
+        if (this.type === 'error') {
+            element.classList.add('notificationError');
+        }
+        element.innerText = this.messageText;
+
+        // add an [X] that makes it hide
+        let xButton = document.createElement('div');
+        xButton.className = 'closeNotification';
+        xButton.innerText = 'X';
+        element.appendChild(xButton);
+
+        xButton.addEventListener('click', function() {
+            this.domElement.remove();
+            if (this.onClose) {
+                this.onClose();
+            }
+            clearTimeout(this.removalTimeout);
+        }.bind(this));
+
+        return element;
+    };
+
+    Notification.prototype.show = function(parentElement, timeToLive) {
+        if (typeof timeToLive === 'undefined') { timeToLive = defaultTimeToLive; }
+
+        parentElement.appendChild(this.domElement);
+        if (timeToLive > 0) {
+            this.removalTimeout = setTimeout(function () {
+                parentElement.removeChild(this.domElement);
+                this.onClose();
+                this.removalTimeout = null;
+            }.bind(this), timeToLive);
+        }
+    };
+
+    function addNotificationListIfNecessary() {
+        if (!notificationList) {
+            notificationList = new NotificationList();
+            notificationList.addToBody();
+        }
+    }
+
+    function NotificationList() {
+        this.element = this.buildElement();
+        this.notifications = [];
+    }
+
+    NotificationList.prototype.buildElement = function() {
+        // add a container
+        let element = document.createElement('div');
+        element.className = 'notificationList';
+        return element;
+    };
+
+    NotificationList.prototype.addToBody = function() {
+        document.body.appendChild(this.element);
+    };
+
+    NotificationList.prototype.showErrorNotification = function(messageText, timeToLive) {
+        this.showNotification(messageText, 'error', timeToLive);
+    };
+
+    NotificationList.prototype.showMessageNotification = function(messageText, timeToLive) {
+        this.showNotification(messageText, 'message', timeToLive);
+    };
+
+    NotificationList.prototype.showNotification = function(messageText, type, timeToLive) {
+        let notification = new Notification(messageText, type, function() {
+            console.log('notificationList removed notification with text: ' + messageText);
+            let index = this.notifications.indexOf(notification);
+            if (index > -1) {
+                this.notifications.splice(index, 1);
+            }
+        }.bind(this));
+        notification.show(this.element, timeToLive);
+        this.notifications.push(notification);
+    };
+
+    exports.showErrorNotification = showErrorNotification;
+    exports.showMessageNotification = showMessageNotification;
+
+})(window);

--- a/server.js
+++ b/server.js
@@ -4367,12 +4367,14 @@ function objectWebServer() {
                                 unzipper.on('extract', function () {
                                     var folderFile = fs.readdirSync(folderD + '/' + identityFolderName + '/target');
                                     var folderFileType;
+                                    let anyTargetsUploaded = false;
 
                                     for (var i = 0; i < folderFile.length; i++) {
                                         console.log(folderFile[i]);
                                         folderFileType = folderFile[i].substr(folderFile[i].lastIndexOf('.') + 1);
                                         if (folderFileType === 'xml' || folderFileType === 'dat') {
                                             fs.renameSync(folderD + '/' + identityFolderName + '/target/' + folderFile[i], folderD + '/' + identityFolderName + '/target/target.' + folderFileType);
+                                            anyTargetsUploaded = true;
                                         }
                                     }
                                     fs.unlinkSync(folderD + '/' + filename);
@@ -4428,8 +4430,13 @@ function objectWebServer() {
                                     let sendObject = {
                                         initialized: false
                                     };
-                                    res.status(200);
-                                    res.json(sendObject);
+                                    if (anyTargetsUploaded) {
+                                        res.status(200).json(sendObject);
+                                    } else {
+                                        res.status(400).json({
+                                            error: 'Unable to extract any target data from provided zip'
+                                        });
+                                    }
                                 });
 
                                 unzipper.on('progress', function (fileIndex, fileCount) {


### PR DESCRIPTION
Adds a notification class that can be easily triggered to add an error or message to the top of the screen for a set amount of time or until the X is pressed. testing it out by adding one error notification if you upload a zip file without any target data to the drop zone. Will add more error notifications for other (currently silent) issues in the future.

![Screen Shot 2020-04-14 at 11 18 26 AM](https://user-images.githubusercontent.com/32580292/79241989-bb62a680-7e41-11ea-8f52-98a7fadf2660.png)