### PR TITLE
Anchor heartbeat bugfix and jpeg support

### DIFF
--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -276,6 +276,27 @@ var getObjectIdFromTargetOrObjectFile = function (folderName, objectsPath) {
 };
 exports.getObjectIdFromTargetOrObjectFile = getObjectIdFromTargetOrObjectFile;
 
+var getAnchorIdFromObjectFile = function (folderName, objectsPath) {
+
+    if (folderName === 'allTargetsPlaceholder') {
+        return 'allTargetsPlaceholder000000000000';
+    }
+
+    var jsonFile = objectsPath + '/' + folderName + '/object.json';
+
+    if (fs.existsSync(jsonFile)) {
+        let thisObject = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
+        if (thisObject.hasOwnProperty('objectId')) {
+            return thisObject.objectId;
+        } else {
+            return null;
+        }
+    } else {
+        return null;
+    }
+};
+exports.getAnchorIdFromObjectFile = getAnchorIdFromObjectFile;
+
 /**
  *
  * @param folderName

--- a/server.js
+++ b/server.js
@@ -529,6 +529,8 @@ var realityEditorBlockSocketArray = {};     // all socket connections that are k
 var realityEditorUpdateSocketArray = {};    // all socket connections to keep UIs in sync (frame position, etc)
 var realityEditorObjectMatrixSocketArray = {};    // all socket connections to keep object world positions in sync
 
+var activeHeartbeats = {}; // Prevents multiple recurring beats for the same object
+
 // counter for the socket connections
 // this counter is used for the Web Developer Interface to reflect the state of the server socket connections.
 var sockets = {
@@ -1019,6 +1021,11 @@ function objectBeatSender(PORT, thisId, thisIp, oneTimeOnly) {
     if (typeof oneTimeOnly === 'undefined') {
         oneTimeOnly = false;
     }
+    
+    if (!oneTimeOnly && activeHeartbeats[thisId]) {
+      console.log('already created beat for object: ' + thisId);
+      return;
+    }
 
     var HOST = '255.255.255.255';
 
@@ -1061,7 +1068,7 @@ function objectBeatSender(PORT, thisId, thisIp, oneTimeOnly) {
     });
 
     if (!oneTimeOnly) {
-        setInterval(function () {
+        activeHeartbeats[thisId] = setInterval(function () {
             // send the beat#
             if (thisId in objects && !objects[thisId].deactivated) {
                 // console.log("Sending beats... Content: " + JSON.stringify({ id: thisId, ip: thisIp, vn:thisVersionNumber, tcs: objects[thisId].tcs}));
@@ -4303,6 +4310,10 @@ function objectWebServer() {
 
                         // remove object from tree
                         if (objects[tempFolderName2]) {
+                            if (activeHeartbeats[tempFolderName2]) {
+                                clearInterval(activeHeartbeats[tempFolderName2]);
+                                delete activeHeartbeats[tempFolderName2];
+                            }
                             delete objects[tempFolderName2];
                             delete knownObjects[tempFolderName2];
                             delete objectLookup[req.body.name];
@@ -4439,6 +4450,10 @@ function objectWebServer() {
                     var tempFolderName2 = utilities.readObject(objectLookup, req.body.name);//req.body.name + thisMacAddress;
                     // remove object from tree
                     if (tempFolderName2 !== null) {
+                        if (activeHeartbeats[tempFolderName2]) {
+                            clearInterval(activeHeartbeats[tempFolderName2]);
+                            delete activeHeartbeats[tempFolderName2];
+                        }
                         delete objects[tempFolderName2];
                         delete knownObjects[tempFolderName2];
                     }
@@ -4625,6 +4640,16 @@ function objectWebServer() {
                                     thisObject.tcs = utilities.generateChecksums(objects, fileList);
                                     utilities.writeObjectToFile(objects, thisObjectId, objectsPath, globalVariables.saveToDisk);
                                     setAnchors();
+                                    
+                                    // Removes old heartbeat if it used to be an anchor
+                                    var oldObjectId = utilities.getAnchorIdFromObjectFile(req.params.id, objectsPath);
+                                    if (oldObjectId && oldObjectId != thisObjectId) {
+                                      console.log('removed old heartbeat for', oldObjectId);
+                                      clearInterval(activeHeartbeats[oldObjectId]);
+                                      delete activeHeartbeats[oldObjectId];
+                                      delete objects[oldObjectId];
+                                    }
+                                    
                                     objectBeatSender(beatPort, thisObjectId, objects[thisObjectId].ip, true);
                                     // res.status(200).send('ok');
                                     res.status(200).json(sendObject);

--- a/server.js
+++ b/server.js
@@ -4499,6 +4499,10 @@ function objectWebServer() {
                     if (req.headers.type === 'targetUpload') {
                         console.log('targetUpload', req.params.id);
                         var fileExtension = getFileExtension(filename);
+                        
+                        if (fileExtension === 'jpeg') { // Needed for compatibility, .JPEG is equivalent to .JPG
+                            fileExtension = 'jpg';
+                        }
 
                         if (fileExtension === 'jpg' || fileExtension === 'dat' || fileExtension === 'xml') {
                             if (!fs.existsSync(folderD + '/' + identityFolderName + '/target/')) {


### PR DESCRIPTION
Fixed an issue where attaching a target to an anchor would make the server advertise both the anchor-version and target-version of the object until the server restarts. JPEG support was added to allow iOS to upload images from the camera roll.