### PR TITLE
Hardware node anchor bugfix

### DIFF
--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -18,10 +18,12 @@
  */
 
 var path = require('path');
+var fs = require('fs');
 var utilities = require('./utilities');
 var _ = require('lodash');
 const Node = require('../models/Node.js');
 const Frame = require('../models/Frame.js');
+const ObjectModel = require('../models/ObjectModel.js');
 
 //global variables, passed through from server.js
 var objects = {};
@@ -34,6 +36,10 @@ var objectsPath;
 var nodeTypeModules;
 // eslint-disable-next-line no-unused-vars
 var blockModules;
+var services;
+var version;
+var protocol;
+var serverPort;
 var callback;
 var actionCallback;
 var publicDataCallBack;
@@ -417,14 +423,45 @@ exports.setTool = function (object, tool, newTool, dirName) {
  **/
 
 exports.addNode = function (object, tool, node, type, position) {
-
     var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
     console.log('hardwareInterfaces.addNode objectID: ', objectID, object, objectsPath);
 
     if (!objectID) {
+        console.log('Creating new object for hardware node', object);
+        
+        var folder = path.join(objectsPath, object);
+        var identityPath = path.join(folder, '.identity');
+        var jsonFilePath = path.join(identityPath, 'object.json');
+        objectID = object + utilities.uuidTime();
+
         utilities.createFolder(object, objectsPath, globalVariables.debug);
-        console.warn('Creating empty folder and giving up');
-        return;
+
+        // create a new anchor object
+        objects[objectID] = new ObjectModel(services.ip, version, protocol);
+        objects[objectID].port = serverPort;
+        objects[objectID].name = object;
+        objects[objectID].ip = services.ip;
+        objects[objectID].objectId = objectID;
+        objects[objectID].isAnchor = true;
+        objects[objectID].matrix = [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1
+        ];
+        objects[objectID].tcs = 0;
+
+        if (globalVariables.saveToDisk) {
+            fs.writeFileSync(jsonFilePath, JSON.stringify(objects[objectID], null, 4), function (err) {
+                if (err) {
+                    console.log('anchor object save error', err);
+                } else {
+                    // console.log('JSON saved to ' + jsonFilePath);
+                }
+            });
+        } else {
+            console.log('I am not allowed to save');
+        }
     }
 
     var nodeUuid = objectID + tool + node;
@@ -674,6 +711,7 @@ exports.setHardwareInterfaceSettingsImpl = function(setHardwareInterfaceSettings
 exports.setup = function setup(objects_, objectLookup_, knownObjects_,
     socketArray_, globalVariables_, dirnameO_,
     objectsPath_, nodeTypeModules_, blockModules_,
+    services_, version_, protocol_, serverPort_,
     hardwareAPICallbacks) {
     objects = objects_;
     objectLookup = objectLookup_;
@@ -684,6 +722,10 @@ exports.setup = function setup(objects_, objectLookup_, knownObjects_,
     objectsPath = objectsPath_;
     nodeTypeModules = nodeTypeModules_;
     blockModules = blockModules_;
+    services = services_;
+    version = version_;
+    protocol = protocol_;
+    serverPort = serverPort_;
     publicDataCallBack = hardwareAPICallbacks.publicData;
     actionCallback = hardwareAPICallbacks.actions;
     callback = hardwareAPICallbacks.data;

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -276,6 +276,27 @@ var getObjectIdFromTargetOrObjectFile = function (folderName, objectsPath) {
 };
 exports.getObjectIdFromTargetOrObjectFile = getObjectIdFromTargetOrObjectFile;
 
+var getAnchorIdFromObjectFile = function (folderName, objectsPath) {
+
+    if (folderName === 'allTargetsPlaceholder') {
+        return 'allTargetsPlaceholder000000000000';
+    }
+
+    var jsonFile = objectsPath + '/' + folderName + '/object.json';
+
+    if (fs.existsSync(jsonFile)) {
+        let thisObject = JSON.parse(fs.readFileSync(jsonFile, 'utf8'));
+        if (thisObject.hasOwnProperty('objectId')) {
+            return thisObject.objectId;
+        } else {
+            return null;
+        }
+    } else {
+        return null;
+    }
+};
+exports.getAnchorIdFromObjectFile = getAnchorIdFromObjectFile;
+
 /**
  *
  * @param folderName

--- a/server.js
+++ b/server.js
@@ -583,7 +583,7 @@ var hardwareAPICallbacks = {
     }
 };
 // set all the initial states for the Hardware Interfaces in order to run with the Server.
-hardwareAPI.setup(objects, objectLookup, knownObjects, socketArray, globalVariables, __dirname, objectsPath, nodeTypeModules, blockModules, hardwareAPICallbacks);
+hardwareAPI.setup(objects, objectLookup, knownObjects, socketArray, globalVariables, __dirname, objectsPath, nodeTypeModules, blockModules, services, version, protocol, serverPort, hardwareAPICallbacks);
 
 console.log('Done');
 
@@ -812,7 +812,7 @@ function loadAnchor(anchorName) {
     // create the file for it if necessary
     var folder = path.join(objectsPath, anchorName);
     var identityPath = path.join(folder, '.identity');
-    var jsonFilePath = path.join(folder, 'object.json');
+    var jsonFilePath = path.join(identityPath, 'object.json');
     let anchorUuid = anchorName + utilities.uuidTime();
 
     // create objects folder at objectsPath if necessary
@@ -859,20 +859,20 @@ function loadAnchor(anchorName) {
     ];
     objects[anchorUuid].tcs = 0;
 
-    objectBeatSender(beatPort, anchorUuid, objects[anchorUuid].ip);
-    hardwareAPI.reset();
-
     if (globalVariables.saveToDisk) {
-
-        fs.writeFile(jsonFilePath, JSON.stringify(objects[anchorUuid], null, 4), function (err) {
+        fs.writeFileSync(jsonFilePath, JSON.stringify(objects[anchorUuid], null, 4), function (err) {
             if (err) {
                 console.log('anchor object save error', err);
             } else {
-                //console.log('JSON saved to ' + jsonFilePath);
+                // console.log('JSON saved to ' + jsonFilePath);
+                objectBeatSender(beatPort, anchorUuid, objects[anchorUuid].ip);
+                hardwareAPI.reset();
             }
         });
     } else {
         console.log('I am not allowed to save');
+        objectBeatSender(beatPort, anchorUuid, objects[anchorUuid].ip);
+        hardwareAPI.reset();
     }
 }
 

--- a/server.js
+++ b/server.js
@@ -529,6 +529,8 @@ var realityEditorBlockSocketArray = {};     // all socket connections that are k
 var realityEditorUpdateSocketArray = {};    // all socket connections to keep UIs in sync (frame position, etc)
 var realityEditorObjectMatrixSocketArray = {};    // all socket connections to keep object world positions in sync
 
+var activeHeartbeats = {}; // Prevents multiple recurring beats for the same object
+
 // counter for the socket connections
 // this counter is used for the Web Developer Interface to reflect the state of the server socket connections.
 var sockets = {
@@ -1019,6 +1021,11 @@ function objectBeatSender(PORT, thisId, thisIp, oneTimeOnly) {
     if (typeof oneTimeOnly === 'undefined') {
         oneTimeOnly = false;
     }
+    
+    if (!oneTimeOnly && activeHeartbeats[thisId]) {
+      console.log('already created beat for object: ' + thisId);
+      return;
+    }
 
     var HOST = '255.255.255.255';
 
@@ -1061,7 +1068,7 @@ function objectBeatSender(PORT, thisId, thisIp, oneTimeOnly) {
     });
 
     if (!oneTimeOnly) {
-        setInterval(function () {
+        activeHeartbeats[thisId] = setInterval(function () {
             // send the beat#
             if (thisId in objects && !objects[thisId].deactivated) {
                 // console.log("Sending beats... Content: " + JSON.stringify({ id: thisId, ip: thisIp, vn:thisVersionNumber, tcs: objects[thisId].tcs}));
@@ -4303,6 +4310,10 @@ function objectWebServer() {
 
                         // remove object from tree
                         if (objects[tempFolderName2]) {
+                            if (activeHeartbeats[tempFolderName2]) {
+                                clearInterval(activeHeartbeats[tempFolderName2]);
+                                delete activeHeartbeats[tempFolderName2];
+                            }
                             delete objects[tempFolderName2];
                             delete knownObjects[tempFolderName2];
                             delete objectLookup[req.body.name];
@@ -4439,6 +4450,10 @@ function objectWebServer() {
                     var tempFolderName2 = utilities.readObject(objectLookup, req.body.name);//req.body.name + thisMacAddress;
                     // remove object from tree
                     if (tempFolderName2 !== null) {
+                        if (activeHeartbeats[tempFolderName2]) {
+                            clearInterval(activeHeartbeats[tempFolderName2]);
+                            delete activeHeartbeats[tempFolderName2];
+                        }
                         delete objects[tempFolderName2];
                         delete knownObjects[tempFolderName2];
                     }
@@ -4625,6 +4640,16 @@ function objectWebServer() {
                                     thisObject.tcs = utilities.generateChecksums(objects, fileList);
                                     utilities.writeObjectToFile(objects, thisObjectId, objectsPath, globalVariables.saveToDisk);
                                     setAnchors();
+                                    
+                                    // Removes old heartbeat if it used to be an anchor
+                                    var oldObjectId = utilities.getAnchorIdFromObjectFile(req.params.id, objectsPath);
+                                    if (oldObjectId && oldObjectId != thisObjectId) {
+                                      console.log('removed old heartbeat for', oldObjectId);
+                                      clearInterval(activeHeartbeats[oldObjectId]);
+                                      delete activeHeartbeats[oldObjectId];
+                                      delete objects[oldObjectId];
+                                    }
+                                    
                                     objectBeatSender(beatPort, thisObjectId, objects[thisObjectId].ip, true);
                                     // res.status(200).send('ok');
                                     res.status(200).json(sendObject);

--- a/server.js
+++ b/server.js
@@ -4499,6 +4499,10 @@ function objectWebServer() {
                     if (req.headers.type === 'targetUpload') {
                         console.log('targetUpload', req.params.id);
                         var fileExtension = getFileExtension(filename);
+                        
+                        if (fileExtension === 'jpeg') { // Needed for compatibility, .JPEG is equivalent to .JPG
+                            fileExtension = 'jpg';
+                        }
 
                         if (fileExtension === 'jpg' || fileExtension === 'dat' || fileExtension === 'xml') {
                             if (!fs.existsSync(folderD + '/' + identityFolderName + '/target/')) {


### PR DESCRIPTION
Resolved #184 #195 
Anchors now store their data in `.identity/object.json` instead of `object.json`.
addNode can now add nodes to anchors (was a bug caused by above issue) and can now create anchors immediately if one doesn't exist (previously it simply created an empty folder and returned without the node).