### PR TITLE
Trigger node's exports.setup and exports.onRemove

### DIFF
--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -287,18 +287,20 @@ const deleteFrame = function(objectId, frameId, body, callback) {
     var objectName = object.name;
     var frameName = object.frames[frameId].name;
 
+    try {
+        console.log(typeof object.frames[frameId].deconstruct);
+        object.frames[frameId].deconstruct();
+    } catch (e) {
+        console.warn('Frame exists without proper prototype: ' + frameId);
+    }
     delete object.frames[frameId];
 
     // remove the frame directory from the object
     utilities.deleteFrameFolder(objectName, frameName, objectsPath);
 
-    // Delete frame's nodes // TODO: I don't think this is updated for the current object/frame/node hierarchy
+    // Delete frame's nodes
     var deletedNodes = {};
     for (var nodeId in frame.nodes) {
-        var thisNode = frame.nodes[nodeId];
-        if (typeof thisNode.deconstruct === 'function') {
-            thisNode.deconstruct();
-        }
         deletedNodes[nodeId] = true;
         delete frame.nodes[nodeId];
     }

--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -52,7 +52,11 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
         newFrame.visibleEditing = frame.visibleEditing;
         newFrame.developer = frame.developer;
         newFrame.links = frame.links;
-        newFrame.nodes = frame.nodes;
+
+        // convert to Node constructors
+        // newFrame.nodes = frame.nodes;
+        newFrame.setNodesFromJson(frame.nodes);
+
         newFrame.location = frame.location;
         newFrame.src = frame.src;
         newFrame.width = frame.width;
@@ -67,12 +71,16 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
 
         object.frames[frameKey] = newFrame;
 
+        console.log('starts: ' + typeof object.frames[frameKey].deconstruct);
+
         utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
         utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: frame.lastEditor});
 
         // notifies any open screens that a new frame was added
         hardwareAPI.runFrameAddedCallbacks(objectKey, newFrame);
 
+        console.log('then: ' + typeof object.frames[frameKey].deconstruct);
+        
         callback(200, {success: true, frameId: frameKey});
     });
 };

--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -294,12 +294,13 @@ const deleteFrame = function(objectId, frameId, body, callback) {
 
     // Delete frame's nodes // TODO: I don't think this is updated for the current object/frame/node hierarchy
     var deletedNodes = {};
-    for (var nodeId in object.nodes) {
-        var node = object.nodes[nodeId];
-        if (node.frame === frameId) {
-            deletedNodes[nodeId] = true;
-            delete object.nodes[nodeId];
+    for (var nodeId in frame.nodes) {
+        var thisNode = frame.nodes[nodeId];
+        if (typeof thisNode.deconstruct === 'function') {
+            thisNode.deconstruct();
         }
+        deletedNodes[nodeId] = true;
+        delete frame.nodes[nodeId];
     }
 
     // Delete links involving frame's nodes

--- a/controllers/logicNode.js
+++ b/controllers/logicNode.js
@@ -68,6 +68,11 @@ const deleteLogicNode = function (objectID, frameID, nodeID, lastEditor) {
 
     var foundFrame = utilities.getFrame(objects, objectID, frameID);
     if (foundFrame) {
+        try {
+            foundFrame.nodes[nodeID].deconstruct();
+        } catch (e) {
+            console.warn('(Logic) Node exists without proper prototype: ' + nodeID);
+        }
         delete foundFrame.nodes[nodeID];
         console.log('deleted node: ' + nodeID);
 

--- a/controllers/node.js
+++ b/controllers/node.js
@@ -22,7 +22,7 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
     if (foundObject) {
         var foundFrame = utilities.getFrame(objects, objectKey, frameKey);
         if (foundFrame) {
-            let node = new Node(body.name, body.type);
+            let node = new Node(body.name, body.type, objectKey, frameKey, nodeKey);
 
             // copy over any additionally-defined properties (node position)
             if (typeof body.x !== 'undefined') {

--- a/controllers/node.js
+++ b/controllers/node.js
@@ -37,7 +37,6 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
             if (typeof body.matrix !== 'undefined') {
                 node.matrix = body.matrix;
             }
-// todo: call setup on the node module
             foundFrame.nodes[nodeKey] = node;
             utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
             utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: body.lastEditor});

--- a/controllers/node.js
+++ b/controllers/node.js
@@ -37,6 +37,7 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
             if (typeof body.matrix !== 'undefined') {
                 node.matrix = body.matrix;
             }
+
             foundFrame.nodes[nodeKey] = node;
             utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
             utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: body.lastEditor});

--- a/controllers/node.js
+++ b/controllers/node.js
@@ -37,7 +37,7 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
             if (typeof body.matrix !== 'undefined') {
                 node.matrix = body.matrix;
             }
-
+// todo: call setup on the node module
             foundFrame.nodes[nodeKey] = node;
             utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
             utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: body.lastEditor});

--- a/libraries/HumanPoseObject.js
+++ b/libraries/HumanPoseObject.js
@@ -136,18 +136,14 @@ HumanPoseObject.prototype.createPoseFrames = function(dontFilterJoints) {
  * @return {Frame}
  */
 HumanPoseObject.prototype.createFrame = function(jointName, shouldCreateNode) {
-    var newFrame = new Frame();
-    newFrame.objectId = this.objectId;
-    newFrame.uuid = this.getFrameKey(jointName);
+    var newFrame = new Frame(this.objectId, this.getFrameKey(jointName));
     newFrame.name = jointName;
     newFrame.distanceScale = 2; // visible from twice as far away as usual frames
     newFrame.ar.scale = 2;
 
     if (shouldCreateNode) {
-        var newNode = new Node('value', 'node');
-        newNode.objectId = this.objectId;
-        newNode.frameId = newFrame.uuid;
-        newNode.uuid = newFrame.uuid + newNode.name;
+        let nodeName = 'value';
+        var newNode = new Node(nodeName, 'node', this.objectId, newFrame.uuid, newFrame.uuid + nodeName);
         newFrame.nodes[newNode.uuid] = newNode;
         newNode.scale = 0.2; // nodes currently have a problem of being rendered too large by default, so decrease scale
     }

--- a/libraries/gitInterface.js
+++ b/libraries/gitInterface.js
@@ -55,8 +55,11 @@ function resetToLastCommit(object, objects, callback) {
                 git.init();
                 return;
             }
-            git.checkout(objectFolderName + identityFile, function () {
+            git.checkout(objectFolderName + identityFile, function (err) {
                 console.log('reset for ', objectFolderName);
+                if (err) {
+                    console.warn('Error resetting to last commit', err);
+                }
                 utilities.updateObject(objectFolderName, objects);
                 utilities.actionSender({reloadObject: {object: object.objectId}, lastEditor: null});
                 callback();

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -414,7 +414,7 @@ exports.setTool = function (object, tool, newTool, dirName) {
                     }
                 }
                 if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
-                    objects[objectID].frames[frameUuid] = new Frame();
+                    objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
                 }
                 //define the tool that is used with this frame
                 objects[objectID].frames[frameUuid].tool = {addon: addonName, interface: interfaceName, tool: newTool};
@@ -447,11 +447,9 @@ exports.addNode = function (object, tool, node, type, position) {
         utilities.createFolder(object, objectsPath, globalVariables.debug);
 
         // create a new anchor object
-        objects[objectID] = new ObjectModel(services.ip, version, protocol);
+        objects[objectID] = new ObjectModel(services.ip, version, protocol, objectID);
         objects[objectID].port = serverPort;
         objects[objectID].name = object;
-        objects[objectID].ip = services.ip;
-        objects[objectID].objectId = objectID;
         objects[objectID].isAnchor = true;
         objects[objectID].matrix = [
             1, 0, 0, 0,
@@ -483,7 +481,7 @@ exports.addNode = function (object, tool, node, type, position) {
             objects[objectID].name = object;
 
             if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
-                objects[objectID].frames[frameUuid] = new Frame();
+                objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
                 utilities.createFrameFolder(object, tool, dirnameO, objectsPath, globalVariables.debug, 'local');
             } else {
                 utilities.createFrameFolder(object, tool, dirnameO, objectsPath, globalVariables.debug, objects[objectID].frames[frameUuid].location);
@@ -498,7 +496,7 @@ exports.addNode = function (object, tool, node, type, position) {
             var thisObject;
 
             if (!objects[objectID].frames[frameUuid].nodes.hasOwnProperty(nodeUuid)) {
-                objects[objectID].frames[frameUuid].nodes[nodeUuid] = new Node(node, type);
+                objects[objectID].frames[frameUuid].nodes[nodeUuid] = new Node(node, type, objectID, frameUuid, nodeUuid);
                 thisObject = objects[objectID].frames[frameUuid].nodes[nodeUuid];
                 thisObject.x = utilities.randomIntInc(0, 200) - 100;
                 thisObject.y = utilities.randomIntInc(0, 200) - 100;
@@ -513,8 +511,6 @@ exports.addNode = function (object, tool, node, type, position) {
             }
 
             thisObject = objects[objectID].frames[frameUuid].nodes[nodeUuid];
-            thisObject.frameId = frameUuid;
-            thisObject.objectId = objectID;
             thisObject.text = undefined;
 
             console.log('added node', {

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -146,6 +146,11 @@ exports.clearObject = function (objectUuid, toolUuid) {
         for (var key in objects[objectID].frames[objectID].nodes) {
             if (!hardwareObjects[objectUuid].nodes.hasOwnProperty(key)) {
                 console.log('Deleting: ' + objectID + '   ' + objectID + '   ' + key);
+                try {
+                    objects[objectID].frames[toolUuid].nodes[key].deconstruct();
+                } catch (e) {
+                    console.warn('Node exists without proper prototype: ' + key);
+                }
                 delete objects[objectID].frames[toolUuid].nodes[key];
             }
         }
@@ -163,6 +168,11 @@ exports.removeAllNodes = function (object, tool) {
                 for (var nodeKey in objects[objectID].frames[frameID].nodes) {
                     deleteLinksToAndFromNode(objectID, frameID, nodeKey);
                     if (!objects[objectID].frames[frameID].nodes.hasOwnProperty(nodeKey)) continue;
+                    try {
+                        objects[objectID].frames[frameID].nodes[nodeKey].deconstruct();
+                    } catch (e) {
+                        console.warn('Node exists without proper prototype: ' + nodeKey);
+                    }
                     delete objects[objectID].frames[frameID].nodes[nodeKey];
                 }
             }
@@ -599,7 +609,11 @@ exports.removeNode = function (object, tool, node) {
                 if (objects[objectID].frames[frameID].nodes.hasOwnProperty(nodeID)) {
                     deleteLinksToAndFromNode(objectID, frameID, nodeID);
                     let thisNode = objects[objectID].frames[frameID].nodes[nodeID];
-                    thisNode.deconstruct();
+                    try {
+                        thisNode.deconstruct();
+                    } catch (e) {
+                        console.warn('Node exists without proper prototype: ' + nodeID);
+                    }
                     delete objects[objectID].frames[frameID].nodes[nodeID];
                 }
             }

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -598,6 +598,8 @@ exports.removeNode = function (object, tool, node) {
             if (objects[objectID].frames.hasOwnProperty(frameID)) {
                 if (objects[objectID].frames[frameID].nodes.hasOwnProperty(nodeID)) {
                     deleteLinksToAndFromNode(objectID, frameID, nodeID);
+                    let thisNode = objects[objectID].frames[frameID].nodes[nodeID];
+                    thisNode.deconstruct();
                     delete objects[objectID].frames[frameID].nodes[nodeID];
                 }
             }

--- a/libraries/recorder.js
+++ b/libraries/recorder.js
@@ -59,7 +59,7 @@ recorder.saveState = function () {
 recorder.recurse = function (obj, objectInTime, keyString) {
     if (!keyString) keyString = '';
     for (let key in obj) { // works for objects and arrays
-        if (!obj.hasOwnProperty(key)) { return; }
+        if (!obj.hasOwnProperty(key)) { return; } // this is important. ignores prototype methods
         let item = obj[key];
         if (typeof item === 'object') {
 

--- a/libraries/recorder.js
+++ b/libraries/recorder.js
@@ -59,6 +59,7 @@ recorder.saveState = function () {
 recorder.recurse = function (obj, objectInTime, keyString) {
     if (!keyString) keyString = '';
     for (let key in obj) { // works for objects and arrays
+        if (!obj.hasOwnProperty(key)) { return; }
         let item = obj[key];
         if (typeof item === 'object') {
 

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -552,6 +552,9 @@ exports.updateObject = function (objectName, objects) {
                     objects[tempFolderName] = JSON.parse(fs.readFileSync(homedir + '/' + objectFolderList[i] + '/' + identityFolderName + '/object.json', 'utf8'));
                     objects[tempFolderName].ip = ip.address();
 
+                    // TODO: properly parse the JSON data into each constructor (Object,Frame,Node)
+                    console.log('SHOULD PARSE OBJECT: ' +  tempFolderName);
+
                     // this is for transforming old lists to new lists
                     if (typeof objects[tempFolderName].objectValues !== 'undefined') {
                         objects[tempFolderName].frames[tempFolderName].nodes = objects[tempFolderName].objectValues;
@@ -875,3 +878,18 @@ const getVideoDir = function (objectsPath, identityFolderName, isMobile, objectN
     return videoDir;
 }
 exports.getVideoDir = getVideoDir;
+
+// copies over properties without interfering with prototype
+exports.assignProperties = function(newInstance, jsonData) {
+    Object.getOwnPropertyNames(newInstance).forEach(function (k) {
+        if (jsonData.hasOwnProperty(k)) {
+            Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
+        }
+    });
+
+    // Object.getOwnPropertyNames(jsonData).forEach(function (k) {
+    //     if (Object.getOwnPropertyNames(newInstance).includes(k)) {
+    //         Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
+    //     }
+    // });
+};

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -573,12 +573,12 @@ exports.updateObject = function (objectName, objects) {
                         delete objects[tempFolderName].links;
                     }
 
-
-                    for (var nodeKey in objects[tempFolderName].frames[tempFolderName].nodes) {
-
-                        if (typeof objects[tempFolderName].nodes[nodeKey].item !== 'undefined') {
-                            var tempItem = objects[tempFolderName].frames[tempFolderName].nodes[nodeKey].item;
-                            objects[tempFolderName].frames[tempFolderName].nodes[nodeKey].data = tempItem[0];
+                    for (var frameKey in objects[tempFolderName].frames) {
+                        for (var nodeKey in objects[tempFolderName].frames[frameKey].nodes) {
+                            if (typeof objects[tempFolderName].frames[frameKey].nodes[nodeKey].item !== 'undefined') {
+                                var tempItem = objects[tempFolderName].frames[frameKey].nodes[nodeKey].item;
+                                objects[tempFolderName].frames[tempFolderName].nodes[nodeKey].data = tempItem[0];
+                            }
                         }
                     }
 
@@ -644,7 +644,7 @@ exports.loadHardwareInterface = function (hardwareInterfaceName) {
         hardwareInterfaces[hardwareInterfaceName] = fileContentsJson;
 
     } catch (e) {
-        console.log('Could not Load: ' + hardwareInterfaceName);
+        console.log('Could not load settings.json for: ' + hardwareInterfaceName);
         hardwareInterfaces[hardwareInterfaceName] = {};
     }
 

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -583,7 +583,10 @@ exports.updateObject = function (objectName, objects) {
                     }
 
                     // cast everything from JSON to Object, Frame, and Node classes
-                    let newObj = new ObjectModel();
+                    let newObj = new ObjectModel(objects[tempFolderName].ip,
+                        objects[tempFolderName].version,
+                        objects[tempFolderName].protocol,
+                        objects[tempFolderName].objectId);
                     newObj.setFromJson(objects[tempFolderName]);
                     objects[tempFolderName] = newObj;
 

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -883,14 +883,3 @@ const getVideoDir = function (objectsPath, identityFolderName, isMobile, objectN
     return videoDir;
 }
 exports.getVideoDir = getVideoDir;
-
-/**
- * Copies all properties from json object into the new class instance
- * @param {Object} newInstance
- * @param {JSON} jsonData
- */
-exports.assignProperties = function(newInstance, jsonData) {
-    Object.getOwnPropertyNames(jsonData).forEach(function (k) {
-        Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
-    });
-};

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -60,6 +60,7 @@ var ip = require('ip');       // get the device IP address library
 var dgram = require('dgram'); // UDP Broadcasting library
 var os = require('os');
 var path = require('path');
+const ObjectModel = require('../models/ObjectModel.js');
 
 var hardwareInterfaces = {};
 
@@ -584,8 +585,11 @@ exports.updateObject = function (objectName, objects) {
                         }
                     }
 
-                    console.log('I found objects that I want to add');
+                    let newObj = new ObjectModel();
+                    newObj.setFromJson(objects[tempFolderName]);
+                    objects[tempFolderName] = newObj;
 
+                    console.log('I found objects that I want to add');
 
                 } catch (e) {
                     objects[tempFolderName].ip = ip.address();
@@ -886,10 +890,4 @@ exports.assignProperties = function(newInstance, jsonData) {
             Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
         }
     });
-
-    // Object.getOwnPropertyNames(jsonData).forEach(function (k) {
-    //     if (Object.getOwnPropertyNames(newInstance).includes(k)) {
-    //         Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
-    //     }
-    // });
 };

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -553,9 +553,6 @@ exports.updateObject = function (objectName, objects) {
                     objects[tempFolderName] = JSON.parse(fs.readFileSync(homedir + '/' + objectFolderList[i] + '/' + identityFolderName + '/object.json', 'utf8'));
                     objects[tempFolderName].ip = ip.address();
 
-                    // TODO: properly parse the JSON data into each constructor (Object,Frame,Node)
-                    console.log('SHOULD PARSE OBJECT: ' +  tempFolderName);
-
                     // this is for transforming old lists to new lists
                     if (typeof objects[tempFolderName].objectValues !== 'undefined') {
                         objects[tempFolderName].frames[tempFolderName].nodes = objects[tempFolderName].objectValues;
@@ -585,6 +582,7 @@ exports.updateObject = function (objectName, objects) {
                         }
                     }
 
+                    // cast everything from JSON to Object, Frame, and Node classes
                     let newObj = new ObjectModel();
                     newObj.setFromJson(objects[tempFolderName]);
                     objects[tempFolderName] = newObj;
@@ -883,11 +881,13 @@ const getVideoDir = function (objectsPath, identityFolderName, isMobile, objectN
 }
 exports.getVideoDir = getVideoDir;
 
-// copies over properties without interfering with prototype
+/**
+ * Copies all properties from json object into the new class instance
+ * @param {Object} newInstance
+ * @param {JSON} jsonData
+ */
 exports.assignProperties = function(newInstance, jsonData) {
-    Object.getOwnPropertyNames(newInstance).forEach(function (k) {
-        if (jsonData.hasOwnProperty(k)) {
-            Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
-        }
+    Object.getOwnPropertyNames(jsonData).forEach(function (k) {
+        Object.defineProperty(newInstance, k, Object.getOwnPropertyDescriptor(jsonData, k));
     });
 };

--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -190,7 +190,7 @@ exports.printFolder = function (objects, objectsPath, debug, objectInterfaceName
 
             // populate the data for each frame template on the frontend, using data from the object json structure
             for (var frameKey in objects[thisObjectKey].frames) {
-                newObject[thisObjectKey].frames[frameKey] = new Frame();
+                newObject[thisObjectKey].frames[frameKey] = new Frame(thisObjectKey, frameKey);
                 newObject[thisObjectKey].frames[frameKey].name = objects[thisObjectKey].frames[frameKey].name;
                 newObject[thisObjectKey].frames[frameKey].location = objects[thisObjectKey].frames[frameKey].location; // 'global' or 'local'
                 newObject[thisObjectKey].frames[frameKey].src = objects[thisObjectKey].frames[frameKey].src; // the frame type, e.g. 'graphUI'

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -1,5 +1,5 @@
-let utilities = require('../libraries/utilities.js');
-let Node = require('./Node.js'); // needs reference to Node constructor
+const utilities = require('../libraries/utilities.js');
+const Node = require('./Node.js'); // needs reference to Node constructor
 
 /**
  * A frame is a component of an object with its own UI and nodes
@@ -79,9 +79,7 @@ Frame.prototype.setNodesFromJson = function(nodes) {
         let name = nodes[nodeKey].name;
         let type = nodes[nodeKey].type;
         let newNode = new Node(name, type);
-        // console.log('asdfn ' + typeof newNode.deconstruct);
         utilities.assignProperties(newNode, nodes[nodeKey]);
-        // console.log('asdfn ' + typeof newNode.deconstruct);
         this.nodes[nodeKey] = newNode;
     }
 };

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -1,5 +1,5 @@
 const utilities = require('../libraries/utilities.js');
-const Node = require('./Node.js'); // needs reference to Node constructor
+const Node = require('./Node.js');
 
 /**
  * A frame is a component of an object with its own UI and nodes
@@ -61,9 +61,11 @@ function Frame() {
     this.groupID = null;
 }
 
-// Gives all this frame's nodes the chance to deconstruct when the frame is deconstructed
+/**
+ * Should be called before deleting the frame in order to properly destroy it
+ * Gives all this frame's nodes the chance to deconstruct when the frame is deconstructed
+ */
 Frame.prototype.deconstruct = function() {
-    console.log('Deconstructing frame (' + this.name + ')');
     for (let nodeKey in this.nodes) {
         if (typeof this.nodes[nodeKey].deconstruct === 'function') {
             this.nodes[nodeKey].deconstruct();
@@ -73,6 +75,11 @@ Frame.prototype.deconstruct = function() {
     }
 };
 
+/**
+ * Parses a json blob of a set of nodes' data into properly constructed Nodes attached to this frame
+ * Should be used instead of frame.nodes = nodes
+ * @param {JSON} nodes
+ */
 Frame.prototype.setNodesFromJson = function(nodes) {
     this.nodes = {};
     for (let nodeKey in nodes) {
@@ -82,10 +89,6 @@ Frame.prototype.setNodesFromJson = function(nodes) {
         utilities.assignProperties(newNode, nodes[nodeKey]);
         this.nodes[nodeKey] = newNode;
     }
-};
-
-Frame.prototype.foo = function() {
-    console.log('foo foo frame');
 };
 
 module.exports = Frame;

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -6,9 +6,11 @@ const Node = require('./Node.js');
  *
  * @constructor
  */
-function Frame() {
+function Frame(objectId, frameId) {
     // The ID for the object will be broadcasted along with the IP. It consists of the name with a 12 letter UUID added.
-    this.objectId = null;
+    this.objectId = objectId;
+    // Stores its own unique ID
+    this.uuid = frameId;
     // The name for the object used for interfaces.
     this.name = '';
     // which visualization mode it should use right now ("ar" or "screen")
@@ -76,16 +78,27 @@ Frame.prototype.deconstruct = function() {
 };
 
 /**
+ * Sets the properties of this frame based on a JSON blob, recursively constructing
+ * its nodes and casting their JSON data to Node instances
+ * @param {JSON} frame
+ */
+Frame.prototype.setFromJson = function(frame) {
+    utilities.assignProperties(this, frame);
+    this.setNodesFromJson(frame.nodes);
+};
+
+/**
  * Parses a json blob of a set of nodes' data into properly constructed Nodes attached to this frame
  * Should be used instead of frame.nodes = nodes
  * @param {JSON} nodes
+ * @param {string} frameId - the uuid of this frame, since this frame doesn't store it
  */
 Frame.prototype.setNodesFromJson = function(nodes) {
     this.nodes = {};
     for (let nodeKey in nodes) {
         let name = nodes[nodeKey].name;
         let type = nodes[nodeKey].type;
-        let newNode = new Node(name, type);
+        let newNode = new Node(name, type, this.objectId, this.uuid, nodeKey);
         utilities.assignProperties(newNode, nodes[nodeKey]);
         this.nodes[nodeKey] = newNode;
     }

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -58,4 +58,20 @@ function Frame() {
     this.groupID = null;
 }
 
+// Gives all this frame's nodes the chance to deconstruct when the frame is deconstructed
+Frame.prototype.deconstruct = function() {
+    console.log('Deconstructing frame (' + this.name + ')');
+    for (let nodeKey in this.nodes) {
+        if (typeof this.nodes[nodeKey].deconstruct === 'function') {
+            this.nodes[nodeKey].deconstruct();
+        } else {
+            console.warn('Node exists without proper prototype: ' + nodeKey);
+        }
+    }
+};
+
+Frame.prototype.foo = function() {
+    console.log('foo foo frame');
+};
+
 module.exports = Frame;

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -1,3 +1,6 @@
+let utilities = require('../libraries/utilities.js');
+let Node = require('./Node.js'); // needs reference to Node constructor
+
 /**
  * A frame is a component of an object with its own UI and nodes
  *
@@ -67,6 +70,19 @@ Frame.prototype.deconstruct = function() {
         } else {
             console.warn('Node exists without proper prototype: ' + nodeKey);
         }
+    }
+};
+
+Frame.prototype.setNodesFromJson = function(nodes) {
+    this.nodes = {};
+    for (let nodeKey in nodes) {
+        let name = nodes[nodeKey].name;
+        let type = nodes[nodeKey].type;
+        let newNode = new Node(name, type);
+        // console.log('asdfn ' + typeof newNode.deconstruct);
+        utilities.assignProperties(newNode, nodes[nodeKey]);
+        // console.log('asdfn ' + typeof newNode.deconstruct);
+        this.nodes[nodeKey] = newNode;
     }
 };
 

--- a/models/Frame.js
+++ b/models/Frame.js
@@ -1,4 +1,3 @@
-const utilities = require('../libraries/utilities.js');
 const Node = require('./Node.js');
 
 /**
@@ -83,7 +82,7 @@ Frame.prototype.deconstruct = function() {
  * @param {JSON} frame
  */
 Frame.prototype.setFromJson = function(frame) {
-    utilities.assignProperties(this, frame);
+    Object.assign(this, frame);
     this.setNodesFromJson(frame.nodes);
 };
 
@@ -91,7 +90,6 @@ Frame.prototype.setFromJson = function(frame) {
  * Parses a json blob of a set of nodes' data into properly constructed Nodes attached to this frame
  * Should be used instead of frame.nodes = nodes
  * @param {JSON} nodes
- * @param {string} frameId - the uuid of this frame, since this frame doesn't store it
  */
 Frame.prototype.setNodesFromJson = function(nodes) {
     this.nodes = {};
@@ -99,7 +97,7 @@ Frame.prototype.setNodesFromJson = function(nodes) {
         let name = nodes[nodeKey].name;
         let type = nodes[nodeKey].type;
         let newNode = new Node(name, type, this.objectId, this.uuid, nodeKey);
-        utilities.assignProperties(newNode, nodes[nodeKey]);
+        Object.assign(newNode, nodes[nodeKey]);
         this.nodes[nodeKey] = newNode;
     }
 };

--- a/models/Node.js
+++ b/models/Node.js
@@ -48,6 +48,9 @@ function Node(name, type) {
     this.setupProgram();
 }
 
+/**
+ * Triggers the exports.setup function defined in the add-on for this node type
+ */
 Node.prototype.setupProgram = function() {
     let nodeTypes = availableModules.getNodes();
     if (typeof nodeTypes[this.type] === 'undefined') {
@@ -60,8 +63,11 @@ Node.prototype.setupProgram = function() {
     }
 };
 
+/**
+ * Should be called before deleting this node
+ * Triggers the exports.onRemove function defined in the add-on for this node type
+ */
 Node.prototype.deconstruct = function() {
-    console.log('Deconstructing node (' + this.name + ')');
     let nodeTypes = availableModules.getNodes();
     if (typeof nodeTypes[this.type] === 'undefined') {
         console.warn('Trying to deconstruct an unsupported node type (' + this.type + ')');

--- a/models/Node.js
+++ b/models/Node.js
@@ -43,8 +43,17 @@ function Node(name, type) {
         let nodeTemplate = nodeTypes[type];
         this.privateData = nodeTemplate.properties.privateData || {};
         this.publicData = nodeTemplate.properties.publicData || {};
+    }
 
-        // trigger the node module's setup function
+    this.setupProgram();
+};
+
+Node.prototype.setupProgram = function() {
+    let nodeTypes = availableModules.getNodes();
+    if (typeof nodeTypes[this.type] === 'undefined') {
+        console.warn('Trying to setup an unsupported node type (' + this.type + ')');
+    } else {
+        let nodeTemplate = nodeTypes[this.type];
         if (typeof nodeTemplate.setup === 'function') {
             nodeTemplate.setup(this);
         }
@@ -52,6 +61,7 @@ function Node(name, type) {
 };
 
 Node.prototype.deconstruct = function() {
+    console.log('Deconstructing node (' + this.name + ')');
     let nodeTypes = availableModules.getNodes();
     if (typeof nodeTypes[this.type] === 'undefined') {
         console.warn('Trying to deconstruct an unsupported node type (' + this.type + ')');

--- a/models/Node.js
+++ b/models/Node.js
@@ -46,7 +46,7 @@ function Node(name, type) {
     }
 
     this.setupProgram();
-};
+}
 
 Node.prototype.setupProgram = function() {
     let nodeTypes = availableModules.getNodes();

--- a/models/Node.js
+++ b/models/Node.js
@@ -43,7 +43,24 @@ function Node(name, type) {
         let nodeTemplate = nodeTypes[type];
         this.privateData = nodeTemplate.properties.privateData || {};
         this.publicData = nodeTemplate.properties.publicData || {};
+
+        // trigger the node module's setup function
+        if (typeof nodeTemplate.setup === 'function') {
+            nodeTemplate.setup(this);
+        }
     }
-}
+};
+
+Node.prototype.deconstruct = function() {
+    let nodeTypes = availableModules.getNodes();
+    if (typeof nodeTypes[this.type] === 'undefined') {
+        console.warn('Trying to deconstruct an unsupported node type (' + this.type + ')');
+    } else {
+        let nodeTemplate = nodeTypes[this.type];
+        if (typeof nodeTemplate.onRemove === 'function') {
+            nodeTemplate.onRemove(this);
+        }
+    }
+};
 
 module.exports = Node;

--- a/models/Node.js
+++ b/models/Node.js
@@ -7,13 +7,15 @@ const availableModules = require('../libraries/availableModules');
  *
  * @constructor
  */
-function Node(name, type) {
+function Node(name, type, objectId, frameId, nodeId) {
     // the name of each link. It is used in the Reality Editor to show the IO name.
     this.name = name || '';
     // the ID of the containing object.
-    this.objectId = null;
+    this.objectId = objectId;
     // the ID of the containing frame.
-    this.frameId = null;
+    this.frameId = frameId;
+    // the ID of this node.
+    this.uuid = nodeId;
     // the actual data of the node
     this.data = new Data();
     // Reality Editor: This is used to position the UI element within its x axis in 3D Space. Relative to Marker origin.

--- a/models/Node.js
+++ b/models/Node.js
@@ -60,7 +60,7 @@ Node.prototype.setupProgram = function() {
     } else {
         let nodeTemplate = nodeTypes[this.type];
         if (typeof nodeTemplate.setup === 'function') {
-            nodeTemplate.setup(this);
+            nodeTemplate.setup(this.objectId, this.frameId, this.uuid, this);
         }
     }
 };
@@ -76,7 +76,7 @@ Node.prototype.deconstruct = function() {
     } else {
         let nodeTemplate = nodeTypes[this.type];
         if (typeof nodeTemplate.onRemove === 'function') {
-            nodeTemplate.onRemove(this);
+            nodeTemplate.onRemove(this.objectId, this.frameId, this.uuid, this);
         }
     }
 };

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -9,10 +9,11 @@ const Frame = require('./Frame.js'); // needs reference to Frame constructor
  * @param {string} ip - ip address of server
  * @param {string} version - Version number of server, currently 3.1.0 or 3.2.0
  * @param {string} protocol - Protocol of object, one of R0, R1, or R2 (current)
+ * @param {string} objectId - Stores its own UUID
  */
-function ObjectModel(ip, version, protocol) {
+function ObjectModel(ip, version, protocol, objectId) {
     // The ID for the object will be broadcasted along with the IP. It consists of the name with a 12 letter UUID added.
-    this.objectId = null;
+    this.objectId = objectId;
     // The name for the object used for interfaces.
     this.name = '';
     this.matrix = [];
@@ -88,7 +89,7 @@ ObjectModel.prototype.setFromJson = function(object) {
 ObjectModel.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
-        let newFrame = new Frame();
+        let newFrame = new Frame(this.objectId, frameKey);
         utilities.assignProperties(newFrame, frames[frameKey]);
         newFrame.setNodesFromJson(frames[frameKey].nodes);
         this.frames[frameKey] = newFrame;

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -56,11 +56,35 @@ function ObjectModel(ip, version, protocol) {
     this.timestamp = null; // timestamp optionally stores when the object was first created
 }
 
+/**
+ * Should be called before deleting the object in order to properly destroy it
+ * Gives all this object's frames the chance to deconstruct when the object is deconstructed
+ */
+ObjectModel.prototype.deconstruct = function() {
+    for (let frameKey in this.frames) {
+        if (typeof this.frames[frameKey].deconstruct === 'function') {
+            this.frames[frameKey].deconstruct();
+        } else {
+            console.warn('Frame exists without proper prototype: ' + frameKey);
+        }
+    }
+};
+
+/**
+ * Sets the properties of this object based on a JSON blob, recursively constructing
+ * its frames and its nodes and casting their JSON data to Frame and Node instances
+ * @param {JSON} object
+ */
 ObjectModel.prototype.setFromJson = function(object) {
     utilities.assignProperties(this, object);
     this.setFramesFromJson(object.frames);
 };
 
+/**
+ * Parses a json blob of a set of frames' data into properly constructed Frames
+ * attached to this object. Should be used instead of object.frames = frames
+ * @param {JSON} frames
+ */
 ObjectModel.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
@@ -68,18 +92,6 @@ ObjectModel.prototype.setFramesFromJson = function(frames) {
         utilities.assignProperties(newFrame, frames[frameKey]);
         newFrame.setNodesFromJson(frames[frameKey].nodes);
         this.frames[frameKey] = newFrame;
-    }
-};
-
-// Gives all this object's frames the chance to deconstruct when the object is deconstructed
-ObjectModel.prototype.deconstruct = function() {
-    console.log('Deconstructing object (' + this.name + ')');
-    for (let frameKey in this.frames) {
-        if (typeof this.frames[frameKey].deconstruct === 'function') {
-            this.frames[frameKey].deconstruct();
-        } else {
-            console.warn('Frame exists without proper prototype: ' + frameKey);
-        }
     }
 };
 

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -53,4 +53,16 @@ function ObjectModel(ip, version, protocol) {
     this.timestamp = null; // timestamp optionally stores when the object was first created
 }
 
+// Gives all this object's frames the chance to deconstruct when the object is deconstructed
+ObjectModel.prototype.deconstruct = function() {
+    console.log('Deconstructing object (' + this.name + ')');
+    for (let frameKey in this.frames) {
+        if (typeof this.frames[frameKey].deconstruct === 'function') {
+            this.frames[frameKey].deconstruct();
+        } else {
+            console.warn('Frame exists without proper prototype: ' + frameKey);
+        }
+    }
+};
+
 module.exports = ObjectModel;

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -1,4 +1,3 @@
-const utilities = require('../libraries/utilities.js');
 const Frame = require('./Frame.js'); // needs reference to Frame constructor
 
 /**
@@ -77,7 +76,7 @@ ObjectModel.prototype.deconstruct = function() {
  * @param {JSON} object
  */
 ObjectModel.prototype.setFromJson = function(object) {
-    utilities.assignProperties(this, object);
+    Object.assign(this, object);
     this.setFramesFromJson(object.frames);
 };
 
@@ -90,7 +89,7 @@ ObjectModel.prototype.setFramesFromJson = function(frames) {
     this.frames = {};
     for (var frameKey in frames) {
         let newFrame = new Frame(this.objectId, frameKey);
-        utilities.assignProperties(newFrame, frames[frameKey]);
+        Object.assign(newFrame, frames[frameKey]);
         newFrame.setNodesFromJson(frames[frameKey].nodes);
         this.frames[frameKey] = newFrame;
     }

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -1,3 +1,6 @@
+const utilities = require('../libraries/utilities.js');
+const Frame = require('./Frame.js'); // needs reference to Frame constructor
+
 /**
  * This is the default constructor for the Reality Object.
  * It contains information about how to render the UI and how to process the internal data.
@@ -52,6 +55,21 @@ function ObjectModel(ip, version, protocol) {
     this.isWorldObject = false;
     this.timestamp = null; // timestamp optionally stores when the object was first created
 }
+
+ObjectModel.prototype.setFromJson = function(object) {
+    utilities.assignProperties(this, object);
+    this.setFramesFromJson(object.frames);
+};
+
+ObjectModel.prototype.setFramesFromJson = function(frames) {
+    this.frames = {};
+    for (var frameKey in frames) {
+        let newFrame = new Frame();
+        utilities.assignProperties(newFrame, frames[frameKey]);
+        newFrame.setNodesFromJson(frames[frameKey].nodes);
+        this.frames[frameKey] = newFrame;
+    }
+};
 
 // Gives all this object's frames the chance to deconstruct when the object is deconstructed
 ObjectModel.prototype.deconstruct = function() {

--- a/server.js
+++ b/server.js
@@ -799,15 +799,18 @@ function loadObjects() {
                     // console.log('asdf ' + typeof newFrame.foo);
                     utilities.assignProperties(newFrame, newObj.frames[frameKey]);
                     // console.log('asdf ' + typeof newFrame.foo);
-                    for (var nodeKey in newFrame.nodes) {
-                        let name = newFrame.nodes[nodeKey].name;
-                        let type = newFrame.nodes[nodeKey].type;
-                        let newNode = new Node(name, type);
-                        // console.log('asdfn ' + typeof newNode.deconstruct);
-                        utilities.assignProperties(newNode, newFrame.nodes[nodeKey]);
-                        // console.log('asdfn ' + typeof newNode.deconstruct);
-                        newFrame.nodes[nodeKey] = newNode;
-                    }
+
+                    newFrame.setNodesFromJson(objects[tempFolderName].frames[frameKey].nodes);
+
+                    // for (var nodeKey in newFrame.nodes) {
+                    //     let name = newFrame.nodes[nodeKey].name;
+                    //     let type = newFrame.nodes[nodeKey].type;
+                    //     let newNode = new Node(name, type);
+                    //     // console.log('asdfn ' + typeof newNode.deconstruct);
+                    //     utilities.assignProperties(newNode, newFrame.nodes[nodeKey]);
+                    //     // console.log('asdfn ' + typeof newNode.deconstruct);
+                    //     newFrame.nodes[nodeKey] = newNode;
+                    // }
                     newObj.frames[frameKey] = newFrame;
                 }
                 objects[tempFolderName] = newObj;
@@ -829,6 +832,18 @@ function loadObjects() {
         utilities.actionSender({reloadObject: {object: tempFolderName}, lastEditor: null});
     }
 
+    console.log('done loading objects');
+    for (let objectKey in objects) {
+        console.log('obj: ' + typeof objects[objectKey].deconstruct);
+        for (let frameKey in objects[objectKey].frames) {
+            console.log('fra: ' + typeof objects[objectKey].frames[frameKey].deconstruct);
+            for (let nodeKey in objects[objectKey].frames[frameKey].nodes) {
+                console.log('obj: ' + typeof objects[objectKey].frames[frameKey].nodes[nodeKey].deconstruct);
+            }
+        }
+    }
+    console.log('done logging objects');
+    
     hardwareAPI.reset();
 }
 
@@ -3680,6 +3695,9 @@ var engine = {
 
         var _this = this;
         if ((thisNode.type in this.nodeTypeModules)) {
+            console.log('obj: ' + typeof objects[object].deconstruct);
+            console.log('fra: ' + typeof objects[object].frames[frame].deconstruct);
+            console.log('nod: ' + typeof objects[object].frames[frame].nodes[node].deconstruct);
             this.nodeTypeModules[thisNode.type].render(object, frame, node, thisNode, function (object, frame, node, thisNode) {
                 _this.processLinks(object, frame, node, thisNode);
             });

--- a/server.js
+++ b/server.js
@@ -2318,6 +2318,9 @@ function objectWebServer() {
 
                     if (objectKey !== null && frameNameKey !== null) {
                         if (thisObject) {
+                            
+                            // deconstruct the nodes on this frame, if needed
+                            
                             delete thisObject.frames[frameNameKey];
                         }
                     }

--- a/server.js
+++ b/server.js
@@ -686,8 +686,6 @@ function loadObjects() {
             objects[tempFolderName] = new ObjectModel(services.ip, version, protocol);
             objects[tempFolderName].port = serverPort;
             objects[tempFolderName].name = objectFolderList[i];
-            
-            console.log('Create ObjectModel for detected object: ' + tempFolderName);
 
             // create first frame
             // todo this need to be checked in the system
@@ -2300,9 +2298,6 @@ function objectWebServer() {
                 var frameName = req.body.frame;
                 var frameNameKey = req.body.frame;
                 var pathKey = req.body.path;
-                
-                let thisFrame = getFrame(objectKey, frameNameKey);
-                // console.log(typeof thisFrame.foo);
 
                 var thisObject = getObject(objectKey);
                 if (thisObject) {
@@ -2329,9 +2324,7 @@ function objectWebServer() {
                         if (thisObject) {
                             try {
                                 // deconstructs the nodes on this frame too, if needed
-                                let thisFrame = thisObject.frames[frameNameKey];
-                                thisFrame.foo();
-                                thisFrame.deconstruct();
+                                thisObject.frames[frameNameKey].deconstruct();
                             } catch (e) {
                                 console.warn('Frame exists without proper prototype: ' + frameNameKey);
                             }
@@ -3603,9 +3596,6 @@ var engine = {
 
         var _this = this;
         if ((thisNode.type in this.nodeTypeModules)) {
-            console.log('obj: ' + typeof objects[object].deconstruct);
-            console.log('fra: ' + typeof objects[object].frames[frame].deconstruct);
-            console.log('nod: ' + typeof objects[object].frames[frame].nodes[node].deconstruct);
             this.nodeTypeModules[thisNode.type].render(object, frame, node, thisNode, function (object, frame, node, thisNode) {
                 _this.processLinks(object, frame, node, thisNode);
             });

--- a/server.js
+++ b/server.js
@@ -686,6 +686,8 @@ function loadObjects() {
             objects[tempFolderName] = new ObjectModel(services.ip, version, protocol);
             objects[tempFolderName].port = serverPort;
             objects[tempFolderName].name = objectFolderList[i];
+            
+            console.log('Create ObjectModel for detected object: ' + tempFolderName);
 
             // create first frame
             // todo this need to be checked in the system
@@ -730,6 +732,87 @@ function loadObjects() {
                         }
                     }
                 }
+
+                console.log('Overwrote ObjectModel with JSON for detected object: ' + tempFolderName);
+
+                // using setPrototypeOf (misses constructor behavior but that's mostly ok)
+                // Object.setPrototypeOf(objects[tempFolderName], ObjectModel.prototype);
+                // for (var frameKey in objects[tempFolderName].frames) {
+                //     Object.setPrototypeOf(objects[tempFolderName].frames[frameKey], Frame.prototype);
+                //     objects[tempFolderName].frames[frameKey].foo();
+                //
+                //     for (var nodeKey in objects[tempFolderName].frames[frameKey].nodes) {
+                //         Object.setPrototypeOf(objects[tempFolderName].frames[frameKey].nodes[nodeKey], Node.prototype);
+                //         // constructor isn't called, so manually call setup
+                //         objects[tempFolderName].frames[frameKey].nodes[nodeKey].setupProgram();
+                //     }
+                // }
+
+                // using assign
+                // let newObj = Object.assign(new ObjectModel(), objects[tempFolderName]);
+                // for (var frameKey in newObj.frames) {
+                //     let newFrame = Object.assign(new Frame(), newObj.frames[frameKey]);
+                //     newFrame.foo();
+                //     for (var nodeKey in newFrame.nodes) {
+                //         let name = newFrame.nodes[nodeKey].name;
+                //         let type = newFrame.nodes[nodeKey].type;
+                //         let newNode = Object.assign(new Node(name, type), newFrame.nodes[nodeKey]);
+                //         newFrame.nodes[nodeKey] = newNode;
+                //     }
+                //     newObj.frames[frameKey] = newFrame;
+                // }
+                // objects[tempFolderName] = newObj;
+
+                // this works but doesn't copy all the properties
+                // let newObj = new ObjectModel();
+                // newObj.name = objects[tempFolderName].name;
+                // for (var frameKey in objects[tempFolderName].frames) {
+                //     let newFrame = new Frame();
+                //     newFrame.name = objects[tempFolderName].frames[frameKey].name;
+                //     newFrame.foo();
+                //     for (var nodeKey in objects[tempFolderName].frames[frameKey].nodes) {
+                //         let name = objects[tempFolderName].frames[frameKey].nodes[nodeKey].name;
+                //         let type = objects[tempFolderName].frames[frameKey].nodes[nodeKey].type;
+                //         let newNode = new Node(name, type);
+                //         newFrame.nodes[nodeKey] = newNode;
+                //     }
+                //     newObj.frames[frameKey] = newFrame;
+                // }
+                // objects[tempFolderName] = newObj;
+
+
+                // var a = {}; // or anything else
+                //
+                // var b = Object.create(
+                //     Object.getPrototypeOf(a)
+                // );
+                //
+                // Object.getOwnPropertyNames(a).forEach(function (k) {
+                //     Object.defineProperty(b, k, Object.getOwnPropertyDescriptor(a, k));
+                // });
+
+                let newObj = new ObjectModel();
+                console.log(Object.getOwnPropertyNames(newObj));
+                utilities.assignProperties(newObj, objects[tempFolderName]);
+                for (var frameKey in newObj.frames) {
+                    let newFrame = new Frame();
+                    // console.log('asdf ' + typeof newFrame.foo);
+                    utilities.assignProperties(newFrame, newObj.frames[frameKey]);
+                    // console.log('asdf ' + typeof newFrame.foo);
+                    for (var nodeKey in newFrame.nodes) {
+                        let name = newFrame.nodes[nodeKey].name;
+                        let type = newFrame.nodes[nodeKey].type;
+                        let newNode = new Node(name, type);
+                        // console.log('asdfn ' + typeof newNode.deconstruct);
+                        utilities.assignProperties(newNode, newFrame.nodes[nodeKey]);
+                        // console.log('asdfn ' + typeof newNode.deconstruct);
+                        newFrame.nodes[nodeKey] = newNode;
+                    }
+                    newObj.frames[frameKey] = newFrame;
+                }
+                objects[tempFolderName] = newObj;
+
+                objects[tempFolderName].deconstruct();
 
                 console.log('I found objects that I want to add');
 
@@ -2294,6 +2377,9 @@ function objectWebServer() {
                 var frameName = req.body.frame;
                 var frameNameKey = req.body.frame;
                 var pathKey = req.body.path;
+                
+                let thisFrame = getFrame(objectKey, frameNameKey);
+                // console.log(typeof thisFrame.foo);
 
                 var thisObject = getObject(objectKey);
                 if (thisObject) {
@@ -2318,9 +2404,14 @@ function objectWebServer() {
 
                     if (objectKey !== null && frameNameKey !== null) {
                         if (thisObject) {
-                            
-                            // deconstruct the nodes on this frame, if needed
-                            
+                            try {
+                                // deconstructs the nodes on this frame too, if needed
+                                let thisFrame = thisObject.frames[frameNameKey];
+                                thisFrame.foo();
+                                thisFrame.deconstruct();
+                            } catch (e) {
+                                console.warn('Frame exists without proper prototype: ' + frameNameKey);
+                            }
                             delete thisObject.frames[frameNameKey];
                         }
                     }
@@ -2344,6 +2435,12 @@ function objectWebServer() {
                             if (activeHeartbeats[tempFolderName2]) {
                                 clearInterval(activeHeartbeats[tempFolderName2]);
                                 delete activeHeartbeats[tempFolderName2];
+                            }
+                            try {
+                                // deconstructs frames and nodes of this object, too
+                                objects[tempFolderName2].deconstruct();
+                            } catch (e) {
+                                console.warn('Object exists without proper prototype: ' + tempFolderName2);
                             }
                             delete objects[tempFolderName2];
                             delete knownObjects[tempFolderName2];
@@ -2484,6 +2581,12 @@ function objectWebServer() {
                         if (activeHeartbeats[tempFolderName2]) {
                             clearInterval(activeHeartbeats[tempFolderName2]);
                             delete activeHeartbeats[tempFolderName2];
+                        }
+                        try {
+                            // deconstructs frames and nodes of this object, too
+                            objects[tempFolderName2].deconstruct();
+                        } catch (e) {
+                            console.warn('Object exists without proper prototype: ' + tempFolderName2);
                         }
                         delete objects[tempFolderName2];
                         delete knownObjects[tempFolderName2];
@@ -2675,16 +2778,22 @@ function objectWebServer() {
                                     thisObject.tcs = utilities.generateChecksums(objects, fileList);
                                     utilities.writeObjectToFile(objects, thisObjectId, objectsPath, globalVariables.saveToDisk);
                                     setAnchors();
-                                    
+
                                     // Removes old heartbeat if it used to be an anchor
                                     var oldObjectId = utilities.getAnchorIdFromObjectFile(req.params.id, objectsPath);
                                     if (oldObjectId && oldObjectId != thisObjectId) {
-                                      console.log('removed old heartbeat for', oldObjectId);
-                                      clearInterval(activeHeartbeats[oldObjectId]);
-                                      delete activeHeartbeats[oldObjectId];
-                                      delete objects[oldObjectId];
+                                        console.log('removed old heartbeat for', oldObjectId);
+                                        clearInterval(activeHeartbeats[oldObjectId]);
+                                        delete activeHeartbeats[oldObjectId];
+                                        try {
+                                            // deconstructs frames and nodes of this object, too
+                                            objects[oldObjectId].deconstruct();
+                                        } catch (e) {
+                                            console.warn('Object exists without proper prototype: ' + tempFolderName2);
+                                        }
+                                        delete objects[oldObjectId];
                                     }
-                                    
+
                                     objectBeatSender(beatPort, thisObjectId, objects[thisObjectId].ip, true);
                                     // res.status(200).send('ok');
                                     res.status(200).json(sendObject);
@@ -2863,7 +2972,13 @@ function createObjectFromTarget(objects, folderVar, __dirname, objectLookup, har
                 }
 
                 if (utilities.readObject(objectLookup, folderVar) !== objectIDXML) {
-                    delete objects[utilities.readObject(objectLookup, folderVar)];
+                    let objectId = utilities.readObject(objectLookup, folderVar);
+                    try {
+                        objects[objectId].deconstruct();
+                    } catch (e) {
+                        console.warn('Object exists without proper prototype: ' + objectId);
+                    }
+                    delete objects[objectId];
                 }
                 utilities.writeObject(objectLookup, folderVar, objectIDXML, globalVariables.saveToDisk);
                 // entering the obejct in to the lookup table
@@ -3298,6 +3413,11 @@ function socketServer() {
                 if (!thisObject.wasUpdated) {
                     console.log('delete human pose object', objectKey);
                     didAnythingChange = true;
+                    try {
+                        objects[objectKey].deconstruct();
+                    } catch (e) {
+                        console.warn('(Human) Object exists without proper prototype: ' + objectKey);
+                    }
                     delete objects[objectKey];
                     // todo: delete folder recursive if necessary?
                     // ^ might not actually be needed, why would human object need to persist?

--- a/server.js
+++ b/server.js
@@ -733,92 +733,11 @@ function loadObjects() {
                     }
                 }
 
-                console.log('Overwrote ObjectModel with JSON for detected object: ' + tempFolderName);
-
-                // using setPrototypeOf (misses constructor behavior but that's mostly ok)
-                // Object.setPrototypeOf(objects[tempFolderName], ObjectModel.prototype);
-                // for (var frameKey in objects[tempFolderName].frames) {
-                //     Object.setPrototypeOf(objects[tempFolderName].frames[frameKey], Frame.prototype);
-                //     objects[tempFolderName].frames[frameKey].foo();
-                //
-                //     for (var nodeKey in objects[tempFolderName].frames[frameKey].nodes) {
-                //         Object.setPrototypeOf(objects[tempFolderName].frames[frameKey].nodes[nodeKey], Node.prototype);
-                //         // constructor isn't called, so manually call setup
-                //         objects[tempFolderName].frames[frameKey].nodes[nodeKey].setupProgram();
-                //     }
-                // }
-
-                // using assign
-                // let newObj = Object.assign(new ObjectModel(), objects[tempFolderName]);
-                // for (var frameKey in newObj.frames) {
-                //     let newFrame = Object.assign(new Frame(), newObj.frames[frameKey]);
-                //     newFrame.foo();
-                //     for (var nodeKey in newFrame.nodes) {
-                //         let name = newFrame.nodes[nodeKey].name;
-                //         let type = newFrame.nodes[nodeKey].type;
-                //         let newNode = Object.assign(new Node(name, type), newFrame.nodes[nodeKey]);
-                //         newFrame.nodes[nodeKey] = newNode;
-                //     }
-                //     newObj.frames[frameKey] = newFrame;
-                // }
-                // objects[tempFolderName] = newObj;
-
-                // this works but doesn't copy all the properties
-                // let newObj = new ObjectModel();
-                // newObj.name = objects[tempFolderName].name;
-                // for (var frameKey in objects[tempFolderName].frames) {
-                //     let newFrame = new Frame();
-                //     newFrame.name = objects[tempFolderName].frames[frameKey].name;
-                //     newFrame.foo();
-                //     for (var nodeKey in objects[tempFolderName].frames[frameKey].nodes) {
-                //         let name = objects[tempFolderName].frames[frameKey].nodes[nodeKey].name;
-                //         let type = objects[tempFolderName].frames[frameKey].nodes[nodeKey].type;
-                //         let newNode = new Node(name, type);
-                //         newFrame.nodes[nodeKey] = newNode;
-                //     }
-                //     newObj.frames[frameKey] = newFrame;
-                // }
-                // objects[tempFolderName] = newObj;
-
-
-                // var a = {}; // or anything else
-                //
-                // var b = Object.create(
-                //     Object.getPrototypeOf(a)
-                // );
-                //
-                // Object.getOwnPropertyNames(a).forEach(function (k) {
-                //     Object.defineProperty(b, k, Object.getOwnPropertyDescriptor(a, k));
-                // });
-
                 let newObj = new ObjectModel();
-                console.log(Object.getOwnPropertyNames(newObj));
-                utilities.assignProperties(newObj, objects[tempFolderName]);
-                for (var frameKey in newObj.frames) {
-                    let newFrame = new Frame();
-                    // console.log('asdf ' + typeof newFrame.foo);
-                    utilities.assignProperties(newFrame, newObj.frames[frameKey]);
-                    // console.log('asdf ' + typeof newFrame.foo);
-
-                    newFrame.setNodesFromJson(objects[tempFolderName].frames[frameKey].nodes);
-
-                    // for (var nodeKey in newFrame.nodes) {
-                    //     let name = newFrame.nodes[nodeKey].name;
-                    //     let type = newFrame.nodes[nodeKey].type;
-                    //     let newNode = new Node(name, type);
-                    //     // console.log('asdfn ' + typeof newNode.deconstruct);
-                    //     utilities.assignProperties(newNode, newFrame.nodes[nodeKey]);
-                    //     // console.log('asdfn ' + typeof newNode.deconstruct);
-                    //     newFrame.nodes[nodeKey] = newNode;
-                    // }
-                    newObj.frames[frameKey] = newFrame;
-                }
+                newObj.setFromJson(objects[tempFolderName]);
                 objects[tempFolderName] = newObj;
 
-                objects[tempFolderName].deconstruct();
-
                 console.log('I found objects that I want to add');
-
 
             } catch (e) {
                 objects[tempFolderName].ip = services.ip; //ip.address();
@@ -832,18 +751,6 @@ function loadObjects() {
         utilities.actionSender({reloadObject: {object: tempFolderName}, lastEditor: null});
     }
 
-    console.log('done loading objects');
-    for (let objectKey in objects) {
-        console.log('obj: ' + typeof objects[objectKey].deconstruct);
-        for (let frameKey in objects[objectKey].frames) {
-            console.log('fra: ' + typeof objects[objectKey].frames[frameKey].deconstruct);
-            for (let nodeKey in objects[objectKey].frames[frameKey].nodes) {
-                console.log('obj: ' + typeof objects[objectKey].frames[frameKey].nodes[nodeKey].deconstruct);
-            }
-        }
-    }
-    console.log('done logging objects');
-    
     hardwareAPI.reset();
 }
 

--- a/server.js
+++ b/server.js
@@ -683,7 +683,7 @@ function loadObjects() {
 
         if (tempFolderName !== null) {
             // fill objects with objects named by the folders in objects
-            objects[tempFolderName] = new ObjectModel(services.ip, version, protocol);
+            objects[tempFolderName] = new ObjectModel(services.ip, version, protocol, tempFolderName);
             objects[tempFolderName].port = serverPort;
             objects[tempFolderName].name = objectFolderList[i];
 
@@ -732,7 +732,10 @@ function loadObjects() {
                 }
 
                 // cast everything from JSON to Object, Frame, and Node classes
-                let newObj = new ObjectModel();
+                let newObj = new ObjectModel(objects[tempFolderName].ip,
+                    objects[tempFolderName].version,
+                    objects[tempFolderName].protocol,
+                    objects[tempFolderName].objectId);
                 newObj.setFromJson(objects[tempFolderName]);
                 objects[tempFolderName] = newObj;
 
@@ -799,14 +802,10 @@ function loadWorldObject() {
     }
 
     // create a new world object
-    worldObject = new ObjectModel(services.ip, version, protocol);
+    let thisWorldObjectId = isMobile ? worldObjectName : (worldObjectName + utilities.uuidTime());
+    worldObject = new ObjectModel(services.ip, version, protocol, thisWorldObjectId);
     worldObject.port = serverPort;
     worldObject.name = worldObjectName;
-    if (isMobile) {
-        worldObject.objectId = worldObjectName;
-    } else {
-        worldObject.objectId = worldObjectName + utilities.uuidTime();
-    }
     worldObject.isWorldObject = true;
 
     // try to read previously saved data to overwrite the default world object
@@ -878,11 +877,9 @@ function loadAnchor(anchorName) {
     }
 
     // create a new anchor object
-    objects[anchorUuid] = new ObjectModel(services.ip, version, protocol);
+    objects[anchorUuid] = new ObjectModel(services.ip, version, protocol, anchorUuid);
     objects[anchorUuid].port = serverPort;
     objects[anchorUuid].name = anchorName;
-    objects[anchorUuid].ip = services.ip;
-    objects[anchorUuid].objectId = anchorUuid;
 
     objects[anchorUuid].isAnchor = false;
     objects[anchorUuid].matrix = [
@@ -2238,9 +2235,8 @@ function objectWebServer() {
                         let isWorldObject = JSON.parse(req.body.isWorld);
                         if (isWorldObject) {
                             let objectId = req.body.name + utilities.uuidTime();
-                            objects[objectId] = new ObjectModel(services.ip, version, protocol);
+                            objects[objectId] = new ObjectModel(services.ip, version, protocol, objectId);
                             objects[objectId].name = req.body.name;
-                            objects[objectId].objectId = objectId;
                             objects[objectId].port = serverPort;
                             objects[objectId].isWorldObject = true;
                             utilities.writeObjectToFile(objects, objectId, objectsPath, globalVariables.saveToDisk);
@@ -2264,7 +2260,7 @@ function objectWebServer() {
                     if (!objects[objectKey].frames[objectKey + req.body.frame]) {
 
                         utilities.createFrameFolder(req.body.name, req.body.frame, __dirname, objectsPath, globalVariables.debug, 'local');
-                        objects[objectKey].frames[objectKey + req.body.frame] = new Frame();
+                        objects[objectKey].frames[objectKey + req.body.frame] = new Frame(objectKey, objectKey + req.body.frame);
                         objects[objectKey].frames[objectKey + req.body.frame].name = req.body.frame;
                         utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
                     } else {
@@ -2867,7 +2863,6 @@ function createObjectFromTarget(objects, folderVar, __dirname, objectLookup, har
                 objects[objectIDXML] = new ObjectModel(services.ip, version, protocol);
                 objects[objectIDXML].port = serverPort;
                 objects[objectIDXML].name = folderVar;
-                objects[objectIDXML].objectId = objectIDXML;
                 objects[objectIDXML].targetSize = objectSizeXML;
 
                 if (objectIDXML.indexOf(worldObjectName) > -1) { // TODO: implement a more robust way to tell if it's a world object
@@ -3408,7 +3403,7 @@ function socketServer() {
             // this function can be called multiple times... only set up the new node if it doesnt already exist
             if (typeof frame.nodes[nodeKey] === 'undefined') {
                 console.log('creating node ' + nodeKey);
-                var newNode = new Node(nodeData.name, nodeData.type);
+                var newNode = new Node(nodeData.name, nodeData.type, objectKey, frameKey, nodeKey);
                 frame.nodes[nodeKey] = newNode;
                 newNode.objectId = objectKey;
                 newNode.frameId = frameKey;

--- a/server.js
+++ b/server.js
@@ -733,6 +733,7 @@ function loadObjects() {
                     }
                 }
 
+                // cast everything from JSON to Object, Frame, and Node classes
                 let newObj = new ObjectModel();
                 newObj.setFromJson(objects[tempFolderName]);
                 objects[tempFolderName] = newObj;


### PR DESCRIPTION
Ensures that Objects, Frames, and Nodes are cast from JSON data to their classes whenever they are loaded into the system. Calls the node's exports.setup function from its constructor. Adds a de-constructor to each class that should be called when deleting it, which ensures that the instance is correctly removed from the system (currently the only effect is triggering the node's onRemove function, but could be expanded in the future)