### PR TITLE
change path for config.html to actually be the html file in the correct path

### DIFF
--- a/libraries/webInterface/gui/index.js
+++ b/libraries/webInterface/gui/index.js
@@ -657,7 +657,7 @@ realityServer.updateManageFrames = function () {
 
 realityServer.selectHardwareInterfaceSettings = function (interfaceName) {
     let ipAddress = realityServer.states.ipAdress.interfaces[realityServer.states.ipAdress.activeInterface];
-    let pathToConfig = 'http://' + ipAddress + ':' + realityServer.states.serverPort + '/hardwareInterface/' + interfaceName;
+    let pathToConfig = 'http://' + ipAddress + ':' + realityServer.states.serverPort + '/hardwareInterface/' + interfaceName + '/config.html';
     let configFrame = document.querySelector('.configFrame');
     configFrame.src = pathToConfig;
 

--- a/server.js
+++ b/server.js
@@ -1827,7 +1827,7 @@ function objectWebServer() {
             res.send(webFrontend.printFolder(objects, objectsPath, globalVariables.debug, objectInterfaceFolder, objectLookup, version, services.ips /*ip.address()*/, serverPort, addonFrames.getFrameList(), hardwareInterfaceModules, framePathList));
         });
 
-        webServer.get(objectInterfaceFolder + 'hardwareInterface/:interfaceName', function (req, res) {
+        webServer.get(objectInterfaceFolder + 'hardwareInterface/:interfaceName/config.html', function (req, res) {
             if (!isMobile) {
                 let interfacePath = hardwareInterfaceLoader.resolvePath(req.params.interfaceName);
                 let configHtmlPath = path.join(interfacePath, req.params.interfaceName, 'config.html');


### PR DESCRIPTION
 so that including libs from its public folder resolve correctly

E.g.
kepware config.html was previously was hosted at: http://localhost:8080/hardwareInterface/kepware
now it is hosted at: http://localhost:8080/hardwareInterface/kepware/config.html

So linking to `<link rel="stylesheet" href="public/test.css"/>` works correctly