### PR TITLE
hotfix for nodes with public data

### DIFF
--- a/models/Node.js
+++ b/models/Node.js
@@ -43,8 +43,8 @@ function Node(name, type, objectId, frameId, nodeId) {
         this.publicData = {};
     } else {
         let nodeTemplate = nodeTypes[type];
-        this.privateData = nodeTemplate.properties.privateData || {};
-        this.publicData = nodeTemplate.properties.publicData || {};
+        this.privateData = Object.assign({}, nodeTemplate.properties.privateData) || {};
+        this.publicData = Object.assign({}, nodeTemplate.properties.publicData) || {};
     }
 
     this.setupProgram();

--- a/models/Node.js
+++ b/models/Node.js
@@ -43,8 +43,8 @@ function Node(name, type, objectId, frameId, nodeId) {
         this.publicData = {};
     } else {
         let nodeTemplate = nodeTypes[type];
-        this.privateData = JSON.parse(JSON.stringify(nodeTemplate.properties.privateData)) || {};
-        this.publicData = JSON.parse(JSON.stringify(nodeTemplate.properties.publicData)) || {};
+        this.privateData = JSON.parse(JSON.stringify(nodeTemplate.properties.privateData || {}));
+        this.publicData = JSON.parse(JSON.stringify(nodeTemplate.properties.publicData || {}));
     }
 
     this.setupProgram();

--- a/models/Node.js
+++ b/models/Node.js
@@ -43,8 +43,8 @@ function Node(name, type, objectId, frameId, nodeId) {
         this.publicData = {};
     } else {
         let nodeTemplate = nodeTypes[type];
-        this.privateData = Object.assign({}, nodeTemplate.properties.privateData) || {};
-        this.publicData = Object.assign({}, nodeTemplate.properties.publicData) || {};
+        this.privateData = JSON.parse(JSON.stringify(nodeTemplate.properties.privateData)) || {};
+        this.publicData = JSON.parse(JSON.stringify(nodeTemplate.properties.publicData)) || {};
     }
 
     this.setupProgram();


### PR DESCRIPTION
public data was being copied by reference (not by value) into each new node so they all shared the same publicData object on the server. so updating the public data of one node was updating them all.

E.g. when you added a drawing tool it would start out with the same drawing as the previously added drawing tools.