### PR TITLE
correctly sets objectId property when uploading a new target image to an object

### DIFF
--- a/server.js
+++ b/server.js
@@ -2905,7 +2905,7 @@ function createObjectFromTarget(objects, folderVar, __dirname, objectLookup, har
         var objectSizeXML = utilities.getTargetSizeFromTarget(folderVar, objectsPath);
         console.log('got ID: objectIDXML');
         if (objectIDXML && objectIDXML.length > 13) {
-            objects[objectIDXML] = new ObjectModel(services.ip, version, protocol);
+            objects[objectIDXML] = new ObjectModel(services.ip, version, protocol, objectIDXML);
             objects[objectIDXML].port = serverPort;
             objects[objectIDXML].name = folderVar;
             objects[objectIDXML].targetSize = objectSizeXML;
@@ -2919,6 +2919,7 @@ function createObjectFromTarget(objects, folderVar, __dirname, objectLookup, har
 
             try {
                 objects[objectIDXML] = JSON.parse(fs.readFileSync(objectsPath + '/' + folderVar + '/' + identityFolderName + '/object.json', 'utf8'));
+                objects[objectIDXML].objectId = objectIDXML;
                 objects[objectIDXML].ip = services.ip; //ip.address();
                 console.log('testing: ' + objects[objectIDXML].ip);
             } catch (e) {


### PR DESCRIPTION
Fixes a small bug where an object's `objectId` property could mismatch the key used to index it in the `objects` data structure after uploading a target image to it.