### PR TITLE
Update userinterface path

### DIFF
--- a/server.js
+++ b/server.js
@@ -1377,7 +1377,7 @@ function objectWebServer() {
     webServer.use('/objectDefaultFiles', express.static(__dirname + '/libraries/objectDefaultFiles/'));
     if (isMobile) {
         const LocalUIApp = require('./libraries/LocalUIApp.js');
-        const uiPath = path.join(__dirname, '../userinterface');
+        const uiPath = path.join(__dirname, '../vuforia-spatial-toolbox-userinterface');
         const localUserInterfaceApp = new LocalUIApp(uiPath, addonFolders);
         localUserInterfaceApp.setup();
         localUserInterfaceApp.listen(serverUserInterfaceAppPort);

--- a/server.js
+++ b/server.js
@@ -1373,12 +1373,14 @@ function objectWebServer() {
     webServer.use(bodyParser.json());
     // define a couple of static directory routs
 
-
     webServer.use('/objectDefaultFiles', express.static(__dirname + '/libraries/objectDefaultFiles/'));
     if (isMobile) {
         const LocalUIApp = require('./libraries/LocalUIApp.js');
         const uiPath = path.join(__dirname, '../vuforia-spatial-toolbox-userinterface');
-        const localUserInterfaceApp = new LocalUIApp(uiPath, addonFolders);
+        const alternativeUiPath = path.join(__dirname, '../userinterface'); // for backwards compatibility
+        const selectedUiPath = fs.existsSync(uiPath) ? uiPath : alternativeUiPath;
+        console.log('SELECTED UI PATH: ' + selectedUiPath);
+        const localUserInterfaceApp = new LocalUIApp(selectedUiPath, addonFolders);
         localUserInterfaceApp.setup();
         localUserInterfaceApp.listen(serverUserInterfaceAppPort);
     }


### PR DESCRIPTION
Allows the userinterface folder to be named either "userinterface" (for backwards compatibility) or "vuforia-spatial-toolbox-userinterface" (the default name when the repository is cloned)

Addresses issue https://github.com/ptcrealitylab/vuforia-spatial-toolbox-ios/issues/4