### PR TITLE
Sends newly initialized node data back to client

### DIFF
--- a/controllers/node.js
+++ b/controllers/node.js
@@ -20,6 +20,7 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
     var errorMessage = null;
 
     var foundObject = utilities.getObject(objects, objectKey);
+    let nodeBody = null;
     if (foundObject) {
         var foundFrame = utilities.getFrame(objects, objectKey, frameKey);
         if (foundFrame) {
@@ -40,6 +41,7 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
             }
 
             foundFrame.nodes[nodeKey] = node;
+            nodeBody = node;
             utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
             utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: body.lastEditor});
             sceneGraph.addNode(objectKey, frameKey, nodeKey, node, node.matrix);
@@ -54,7 +56,11 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
     if (errorMessage) {
         callback(404, {failure: true, error: errorMessage});
     } else {
-        callback(200, {success: 'true'});
+        let response = {success: 'true'};
+        if (nodeBody) {
+            response.node = JSON.stringify(nodeBody);
+        }
+        callback(200, response);
     }
 };
 

--- a/models/Node.js
+++ b/models/Node.js
@@ -51,6 +51,8 @@ function Node(name, type, objectId, frameId, nodeId) {
         }
     }
 
+    console.log(nodeId + ' invisible?', this.invisible);
+
     this.setupProgram();
 }
 

--- a/models/Node.js
+++ b/models/Node.js
@@ -51,8 +51,6 @@ function Node(name, type, objectId, frameId, nodeId) {
         }
     }
 
-    console.log(nodeId + ' invisible?', this.invisible);
-
     this.setupProgram();
 }
 


### PR DESCRIPTION
Corresponding server update for userinterface PR: https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/159

Fixes issue where invisibility and other node properties weren't sent back to the userinterface when a new node is initialized with the POST /addNode API