### PR TITLE
adds API for stickNodeToScreen(nodeName) 

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -577,6 +577,8 @@
                 this.setExclusiveFullScreenOn = makeSendStub('setExclusiveFullScreenOn');
                 this.setExclusiveFullScreenOff = makeSendStub('setExclusiveFullScreenOff');
                 this.isExclusiveFullScreenOccupied = makeSendStub('isExclusiveFullScreenOccupied');
+                this.stickNodeToScreen = makeSendStub('stickNodeToScreen');
+                this.unstickNodeFromScreen = makeSendStub('unstickNodeFromScreen');
                 this.startVideoRecording = makeSendStub('startVideoRecording');
                 this.stopVideoRecording = makeSendStub('stopVideoRecording');
                 this.getScreenshotBase64 = makeSendStub('getScreenshotBase64');
@@ -1284,6 +1286,20 @@
 
             postDataToParent({
                 getIsExclusiveFullScreenOccupied: true
+            });
+        };
+
+        this.stickNodeToScreen = function(name) {
+            postDataToParent({
+                nodeName: name,
+                nodeIsFullScreen: true
+            });
+        };
+
+        this.unstickNodeFromScreen = function(name) {
+            postDataToParent({
+                nodeName: name,
+                nodeIsFullScreen: false
             });
         };
 


### PR DESCRIPTION
to render the node on the screen instead of in 3D space

How to use in a tool:

```
realityInterface.initNode('left', 'node', -100, 0);
realityInterface.initNode('right', 'node', 100, 0);
realityInterface.initNode('top', 'node', 0, -100);
realityInterface.initNode('bottom', 'node', 0, 100);
realityInterface.stickNodeToScreen('left');
realityInterface.stickNodeToScreen('right');
realityInterface.stickNodeToScreen('top');
realityInterface.stickNodeToScreen('bottom');
```

![IMG_EA9774C09C3B-1](https://user-images.githubusercontent.com/32580292/128918617-9fb22541-1742-4af9-87fb-26625ad8ef39.jpeg)