### PR TITLE
adds a POST /object/:id/generateFrame route 

### DIFF
--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -82,7 +82,7 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
 const generateFrameOnObject = function (objectKey, frameType, relativeMatrix, callback) {
     let object = utilities.getObject(objects, objectKey);
     if (!object) {
-        callback(404, error);
+        callback(404, {failure: true, error: 'object with id ' + objectKey + ' does not exist'});
         return;
     }
 

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -676,6 +676,47 @@ exports.pushUpdatesToDevices = function (object) {
     actionCallback({reloadObject: {object: objectID}});
 };
 
+exports.generateFrame = function (objectName, frameType, relativeMatrix) {
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(objectName, objectsPath);
+    console.log('hardwareInterfaces.generateFrame on object ' + objectID);
+
+    if (!objectID || !objects.hasOwnProperty(objectID)) {
+        console.warn('The object ' + objectName + ' doesn\'t exist.. cannot generateFrame');
+        return;
+    }
+
+    let object = utilities.getObject(objects, objectID);
+
+    if (!object.frames) {
+        object.frames = {};
+    }
+
+    let frameKey = objectID + frameType + utilities.uuidTime();
+    let newFrame = new Frame(objectID, frameKey);
+    newFrame.name = frameType;
+    newFrame.location = 'global';
+    newFrame.src = frameType;
+
+    if (typeof relativeMatrix !== 'undefined' && Array.isArray(relativeMatrix) && relativeMatrix.length === 16 && typeof relativeMatrix[0] === 'number') {
+        newFrame.ar.matrix = relativeMatrix;
+    }
+
+    object.frames[frameKey] = newFrame;
+
+    console.log('generated frame of type ' + frameType + ' on object ' + objectID);
+
+    utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+
+    // sceneGraph.addFrame(objectKey, frameKey, newFrame, newFrame.ar.matrix);
+
+    // notifies any open screens that a new frame was added
+    // hardwareAPI.runFrameAddedCallbacks(objectKey, newFrame);
+
+    this.pushUpdatesToDevices(objectName);
+
+    return newFrame;
+};
+
 exports.activate = function (object) {
     var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
     if (objectID) {

--- a/routers/object.js
+++ b/routers/object.js
@@ -317,6 +317,17 @@ router.post('/:objectName/addFrame/', function (req, res) {
         res.status(statusCode).json(responseContents).end();
     });
 });
+router.post('/:objectName/generateFrame', function(req, res) {
+    if (!utilities.isValidId(req.params.objectName)) {
+        res.status(400).send('Invalid object name. Must be alphanumeric.');
+        return;
+    }
+
+    frameController.generateFrameOnObject(req.params.objectName, req.body.frameType, req.body.relativeMatrix, function(statusCode, responseContents) {
+        res.status(statusCode).json(responseContents).end();
+    });
+});
+
 // Update the publicData of a frame when it gets moved from one object to another
 router.delete('/:objectName/frame/:frameName/publicData', function (req, res) {
     if (!utilities.isValidId(req.params.objectName) || !utilities.isValidId(req.params.frameName)) {


### PR DESCRIPTION
How does this look?

The request just needs frameType and relativeMatrix in the body and does all the other work to create the frame on the specified object and notify any clients to load it.

example: 

```
curl --header "Content-type: application/json" -d "{\"frameType\":\"graphUI\", \"relativeMatrix\":[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]}" http://localhost:8080/object/test_Peoqk0h4lgb/generateFrame 
```
^ This will create a graphUI frame and add it to my object named test (uuid = test_Peoqk0h4lgb), and position it centered on the object