### PR TITLE
fix longtime subtle bug where fullscreen tools (e.g. threejs) blocked pointermove and pointerup...

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -71,6 +71,7 @@
             type: null},
         touchDecider: null,
         touchDeciderRegistered: false,
+        unacceptedTouchInProgress: false,
         ignoreAllTouches: false,
         // onFullScreenEjected: null,
         onload: null
@@ -381,8 +382,19 @@
                     postDataToParent({
                         unacceptedTouch: eventData
                     });
+                    spatialObject.unacceptedTouchInProgress = true;
                     return;
                 }
+            }
+
+            if (spatialObject.touchDeciderRegistered && spatialObject.unacceptedTouchInProgress) {
+                postDataToParent({
+                    unacceptedTouch: eventData
+                });
+                if (eventData.type === 'pointerup') {
+                    spatialObject.unacceptedTouchInProgress = false;
+                }
+                return;
             }
 
             // if it wasn't unaccepted, dispatch a touch event into the page contents


### PR DESCRIPTION
...events on tools underneath them even if touchDecider (raycast) returned false within the tool. Noticed this behavior on the remote operator where communication tools would received pointerdown events when threejs tools are in the scene, but not pointerup or pointermove. Adjusted object.js library to propagate these events too.