### PR TITLE
fix touch interaction APIs for loto envelope

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -611,6 +611,7 @@
                 this.enableCustomInteractionMode = makeSendStub('enableCustomInteractionMode');
                 this.enableCustomInteractionModeInverted = makeSendStub('enableCustomInteractionModeInverted');
                 this.setInteractableDivs = makeSendStub('setInteractableDivs');
+                this.disableCustomInteractionMode = makeSendStub('disableCustomInteractionMode');
                 this.subscribeToFrameCreatedEvents = makeSendStub('subscribeToFrameCreatedEvents');
                 this.subscribeToFrameDeletedEvents = makeSendStub('subscribeToFrameDeletedEvents');
                 this.subscribeToToolCreatedEvents = makeSendStub('subscribeToToolCreatedEvents');
@@ -1476,6 +1477,14 @@
         };
 
         /**
+         * Resets state from enableCustomInteractionMode and enableCustomInteractionModeInverted
+         */
+        this.disableCustomInteractionMode = function() {
+            spatialObject.customInteractionMode = false;
+            spatialObject.invertedInteractionMode = false;
+        };
+
+        /**
          * Add a callback that will be triggered anytime another new frame is created while this frame is loaded in the DOM
          * The callback will be passed the frameId (uuid of the frame) and the frame type (e.g. graph, slider, loto, etc)
          * This is useful to create relationships between frames and store the frameId for future message passing
@@ -1960,7 +1969,7 @@
         // by default, register a touch decider that ignores touches if they hit a transparent body background
         this.registerTouchDecider(function(eventData) {
             var elt = document.elementFromPoint(eventData.x, eventData.y);
-            return elt !== document.body;
+            return !(elt === document.body || elt === document.body.parentElement);
         });
 
         this.unregisterTouchDecider = function() {

--- a/server.js
+++ b/server.js
@@ -3507,7 +3507,7 @@ function socketServer() {
             }
 
             for (var socketId in realityEditorObjectMatrixSocketArray) {
-                if (msgContent.hasOwnProperty('editorId') && realityEditorUpdateSocketArray[socketId] && msgContent.editorId === realityEditorUpdateSocketArray[socketId].editorId) {
+                if (msgContent.hasOwnProperty('editorId') && realityEditorObjectMatrixSocketArray[socketId] && msgContent.editorId === realityEditorObjectMatrixSocketArray[socketId].editorId) {
                     continue; // don't send updates to the editor that triggered it
                 }
 


### PR DESCRIPTION
Not sure if it was a browser update but need to ignore touches on html document as well as body element in order for them to pass thru open LOTO envelope and into the LOTO steps. Also adds a missing API `disableCustomInteractionMode` that LOTO can use to cancel out some special listeners it's using when the envelope is closed.

Also fixes one random typo with socket names that didn't seem to be causing any issues.