### PR TITLE
adds support for optional unitypackage target file (in addition to xml, dat, and glb)

### DIFF
--- a/controllers/object.js
+++ b/controllers/object.js
@@ -150,7 +150,7 @@ const setMatrix = function(objectID, body, callback) {
     }
 
     object.matrix = body.matrix;
-    console.log('set matrix for ' + objectID + ' to ' + object.matrix.toString());
+    // console.log('set matrix for ' + objectID + ' to ' + object.matrix.toString());
 
     if (typeof body.worldId !== 'undefined' && body.worldId !== object.worldId) {
         object.worldId = body.worldId;

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -377,7 +377,7 @@ exports.writeObjectToFile = function (objects, object, objectsPath, writeToFile)
 };
 
 function executeWrite(objects) {
-    console.log('execute write');
+    // console.log('execute write');
     // if write Buffer is empty, stop.
     if (Object.keys(writeBufferList).length === 0) return;
 

--- a/server.js
+++ b/server.js
@@ -1544,7 +1544,7 @@ function objectWebServer() {
         var switchToInteraceTool = true;
         if (!toolpath) switchToInteraceTool = false;
 
-        if ((urlArray[urlArray.length - 1] === 'target.dat' || urlArray[urlArray.length - 1] === 'target.jpg' || urlArray[urlArray.length - 1] === 'target.xml' || urlArray[urlArray.length - 1] === 'target.glb')
+        if ((urlArray[urlArray.length - 1] === 'target.dat' || urlArray[urlArray.length - 1] === 'target.jpg' || urlArray[urlArray.length - 1] === 'target.xml' || urlArray[urlArray.length - 1] === 'target.glb' || urlArray[urlArray.length - 1] === 'target.unitypackage')
             && urlArray[urlArray.length - 2] === 'target') {
             urlArray[urlArray.length - 2] = identityFolderName + '/target';
             switchToInteraceTool = false;
@@ -2920,7 +2920,7 @@ function objectWebServer() {
                                     for (var i = 0; i < folderFile.length; i++) {
                                         console.log(folderFile[i]);
                                         folderFileType = folderFile[i].substr(folderFile[i].lastIndexOf('.') + 1);
-                                        if (folderFileType === 'xml' || folderFileType === 'dat' || folderFileType === 'glb') {
+                                        if (folderFileType === 'xml' || folderFileType === 'dat' || folderFileType === 'glb' || folderFileType === 'unitypackage') {
                                             fs.renameSync(folderD + '/' + identityFolderName + '/target/' + folderFile[i], folderD + '/' + identityFolderName + '/target/target.' + folderFileType);
                                             anyTargetsUploaded = true;
                                         }
@@ -2930,7 +2930,7 @@ function objectWebServer() {
                                             for (let j = 0; j < innerFolderFiles.length; j++) {
                                                 console.log(innerFolderFiles[j]);
                                                 folderFileType = innerFolderFiles[j].substr(innerFolderFiles[j].lastIndexOf('.') + 1);
-                                                if (folderFileType === 'xml' || folderFileType === 'dat' || folderFileType === 'glb') {
+                                                if (folderFileType === 'xml' || folderFileType === 'dat' || folderFileType === 'glb' || folderFileType === 'unitypackage') {
                                                     fs.renameSync(folderD + '/' + identityFolderName + '/target/' + folderFile[i] + '/' + innerFolderFiles[j], folderD + '/' + identityFolderName + '/target/target.' + folderFileType);
                                                     anyTargetsUploaded = true;
                                                 }


### PR DESCRIPTION
New iOS app version will generate this file from the area target scanner and include it in the zip that is uploaded to the server. `target.unitypackage` is available at path, e.g. http://localhost:8080/obj/_WORLD_instantScan/target/target.unitypackage
