### PR TITLE
Always setup LocalUIApp; Serve fbx, gltf, and glb files

### DIFF
--- a/libraries/LocalUIApp.js
+++ b/libraries/LocalUIApp.js
@@ -62,7 +62,11 @@ class LocalUIApp {
             }
             res.status(403).send('access prohibited to non-script non-style file');
         });
-        this.app.use(express.static(this.userinterfacePath));
+        if (this.userinterfacePath && fs.existsSync(this.userinterfacePath)) {
+            this.app.use(express.static(this.userinterfacePath));
+        } else {
+            console.warn('LocalUIApp missing userinterfacePath');
+        }
     }
 
     /**
@@ -129,7 +133,9 @@ class LocalUIApp {
             }
             const fileList = fs.readdirSync(uiPath).filter(function (filename) {
                 // this list can be extended in future to support more resource types
-                return filename.endsWith('.svg') || filename.endsWith('.png');
+                return filename.endsWith('.svg') || filename.endsWith('.png') ||
+                    filename.endsWith('.fbx') || filename.endsWith('.gltf') ||
+                    filename.endsWith('.glb');
             });
             if (fileList.length === 0) {
                 continue;

--- a/server.js
+++ b/server.js
@@ -1413,16 +1413,16 @@ function objectWebServer() {
     // define a couple of static directory routs
 
     webServer.use('/objectDefaultFiles', express.static(__dirname + '/libraries/objectDefaultFiles/'));
-    if (isMobile) {
-        const LocalUIApp = require('./libraries/LocalUIApp.js');
-        const uiPath = path.join(__dirname, '../vuforia-spatial-toolbox-userinterface');
-        const alternativeUiPath = path.join(__dirname, '../userinterface'); // for backwards compatibility
-        const selectedUiPath = fs.existsSync(uiPath) ? uiPath : alternativeUiPath;
-        console.log('SELECTED UI PATH: ' + selectedUiPath);
-        const localUserInterfaceApp = new LocalUIApp(selectedUiPath, addonFolders);
-        localUserInterfaceApp.setup();
-        localUserInterfaceApp.listen(serverUserInterfaceAppPort);
-    }
+
+    const LocalUIApp = require('./libraries/LocalUIApp.js');
+    const uiPath = path.join(__dirname, '../vuforia-spatial-toolbox-userinterface');
+    const alternativeUiPath = path.join(__dirname, '../userinterface'); // for backwards compatibility
+    const selectedUiPath = fs.existsSync(uiPath) ? uiPath : alternativeUiPath;
+    console.log('SELECTED UI PATH: ' + selectedUiPath);
+    const localUserInterfaceApp = new LocalUIApp(selectedUiPath, addonFolders);
+    localUserInterfaceApp.setup();
+    localUserInterfaceApp.listen(serverUserInterfaceAppPort);
+
     // webServer.use('/frames', express.static(__dirname + '/libraries/frames/'));
 
     webServer.use('/frames/:frameName', function (req, res, next) {


### PR DESCRIPTION
The decision to only LocalUIApp looks like it's out of sync with LocalUIApp also serving add-on resources.

After this it'll be possible to access /addons/vuforia-spatial-remote-operator-addon/content_resources/hololens.fbx at http://localhost:49368/addons/vuforia-spatial-remote-operator-addon/hololens.fbx