### PR TITLE
adds a projectedZ property to touch events, if the userinterface provides it

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -439,6 +439,9 @@
             if (typeof eventData.projectedZ !== 'undefined') {
                 event.projectedZ = eventData.projectedZ;
             }
+            if (typeof eventData.worldIntersectPoint !== 'undefined') {
+                event.worldIntersectPoint = eventData.worldIntersectPoint;
+            }
 
             // send unacceptedTouch message if this interface wants touches to pass through it
             if (spatialObject.touchDeciderRegistered && eventData.type === 'pointerdown') {

--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -436,6 +436,10 @@
                 screenY: eventData.y
             });
 
+            if (typeof eventData.projectedZ !== 'undefined') {
+                event.projectedZ = eventData.projectedZ;
+            }
+
             // send unacceptedTouch message if this interface wants touches to pass through it
             if (spatialObject.touchDeciderRegistered && eventData.type === 'pointerdown') {
                 var touchAccepted = spatialObject.touchDecider(eventData);


### PR DESCRIPTION
Tools can access the projectedZ from pointerevent listeners and also in the touchDecider function

e.g.
```
document.addEventListener('pointerdown', e => {
  console.log(e.projectedZ);
})
```
or
```
spatialInterface.registerTouchDecider(e => {
  console.log(e.projectedZ);
  // ...
  return intersects.length > 0;
})
```