### PR TITLE
Mobile cleanup update

### DIFF
--- a/scripts/mobile-cleanup.sh
+++ b/scripts/mobile-cleanup.sh
@@ -4,5 +4,5 @@ set -ex
 # this would be good but prevents undoing this
 # rm -fr .git
 # rm -r hardwareInterfaces/*
-npm prune --production
-npm uninstall --production --no-save archiver change-case decompress-size directory-tree express-handlebars lodash monaco-editor network-interfaces node-persist readdirp sharp simple-git smtp-server xmljs
+npm ci --omit=dev
+npm uninstall --omit=dev --no-save archiver directory-tree monaco-editor node-persist readdirp simple-git

--- a/server.js
+++ b/server.js
@@ -371,7 +371,7 @@ if (isLightweightMobile) {
 const HumanPoseObject = require('./libraries/HumanPoseObject');
 
 var git;
-if (isLightweightMobile || process.env.NODE_ENV === 'test') {
+if (isStandaloneMobile || isLightweightMobile || process.env.NODE_ENV === 'test') {
     git = null;
 } else {
     git = require('./libraries/gitInterface');


### PR DESCRIPTION
Running scripts/mobile-cleanup.sh will result in a pretty significant improvement to compile and install times. Other wins can be had by running `npm ci --omit=dev` in all the addon folders and removing `@ffmpeg-installer/ffmpeg` from the remote operator addon.