### PR TITLE
Uses StaleObjectCleaner and heartbeats to delete old avatars and human pose objects

### DIFF
--- a/libraries/StaleObjectCleaner.js
+++ b/libraries/StaleObjectCleaner.js
@@ -1,0 +1,52 @@
+
+class StaleObjectCleaner {
+    constructor(objects, deleteObjectCallback) {
+        this.objectsRef = objects;
+        this.intervals = {};
+        this.deleteObjectCallback = deleteObjectCallback;
+        this.lastUpdates = {};
+    }
+
+    createCleanupInterval(intervalLengthMs, expirationTimeMs, objectTypesToCheck) {
+        const intervalHandle = setInterval(() => {
+            this.cleanupStaleObjects(expirationTimeMs, objectTypesToCheck);
+        }, intervalLengthMs);
+
+        this.intervals[intervalHandle] = {
+            expirationTime: expirationTimeMs,
+            objectTypesToCheck: objectTypesToCheck
+        };
+    }
+
+    resetObjectTimeout(objectKey) {
+        this.lastUpdates[objectKey] = Date.now();
+    }
+
+    getLastUpdateTime(objectKey) {
+        if (typeof this.lastUpdates[objectKey] === 'undefined') {
+            // if it hasn't been updated yet, measure the timeout against the first time it is checked
+            this.resetObjectTimeout(objectKey);
+        }
+        return this.lastUpdates[objectKey];
+    }
+
+    cleanupStaleObjects(expirationTimeMs, objectTypesToCheck) {
+        for (const [objectKey, object] of Object.entries(this.objectsRef)) {
+            if (!objectTypesToCheck.includes(object.type)) {
+                continue;
+            }
+
+            // get time of last update for this object
+            let lastUpdateTime = this.getLastUpdateTime(objectKey);
+            let currentTime = Date.now();
+
+            // delete the object if it hasn't been updated recently
+            if (lastUpdateTime && (currentTime - lastUpdateTime > expirationTimeMs)) {
+                console.log('StaleObjectCleaner deleted object (last updated ' + (currentTime - lastUpdateTime) + ' ms ago)', objectKey);
+                this.deleteObjectCallback(objectKey);
+            }
+        }
+    }
+}
+
+module.exports = StaleObjectCleaner;

--- a/libraries/StaleObjectCleaner.js
+++ b/libraries/StaleObjectCleaner.js
@@ -1,33 +1,24 @@
-
+// Periodically checks each object of specific types (e.g. avatars or human pose) and deletes them if they haven't been
+// updated in the last X seconds (or refreshed with a keepObjectAlive UDP action message)
 class StaleObjectCleaner {
     constructor(objects, deleteObjectCallback) {
         this.objectsRef = objects;
-        this.intervals = {};
         this.deleteObjectCallback = deleteObjectCallback;
         this.lastUpdates = {};
     }
 
+    // starts the periodic checking of objects
+    // note: the same StaleObjectCleaner can manage multiple intervals, for example if you want to check avatar objects
+    // at one frequency, and human pose objects at another frequency
     createCleanupInterval(intervalLengthMs, expirationTimeMs, objectTypesToCheck) {
-        const intervalHandle = setInterval(() => {
+        setInterval(() => {
             this.cleanupStaleObjects(expirationTimeMs, objectTypesToCheck);
         }, intervalLengthMs);
-
-        this.intervals[intervalHandle] = {
-            expirationTime: expirationTimeMs,
-            objectTypesToCheck: objectTypesToCheck
-        };
     }
 
+    // call this externally anytime the object is updated so that we give it more time to live
     resetObjectTimeout(objectKey) {
         this.lastUpdates[objectKey] = Date.now();
-    }
-
-    getLastUpdateTime(objectKey) {
-        if (typeof this.lastUpdates[objectKey] === 'undefined') {
-            // if it hasn't been updated yet, measure the timeout against the first time it is checked
-            this.resetObjectTimeout(objectKey);
-        }
-        return this.lastUpdates[objectKey];
     }
 
     cleanupStaleObjects(expirationTimeMs, objectTypesToCheck) {
@@ -46,6 +37,14 @@ class StaleObjectCleaner {
                 this.deleteObjectCallback(objectKey);
             }
         }
+    }
+
+    getLastUpdateTime(objectKey) {
+        if (typeof this.lastUpdates[objectKey] === 'undefined') {
+            // if it hasn't been updated yet, measure the timeout against the first time it is checked
+            this.resetObjectTimeout(objectKey);
+        }
+        return this.lastUpdates[objectKey];
     }
 }
 

--- a/libraries/sceneGraph/SceneGraph.js
+++ b/libraries/sceneGraph/SceneGraph.js
@@ -2,7 +2,7 @@ let SceneNode = require('./SceneNode');
 let utils = require('./utils');
 const actionSender = require('../utilities').actionSender;
 const { SceneGraphEvent, SceneGraphEventOpEnum, SceneGraphNetworkManager } = require('./SceneGraphNetworking');
-const { getIP, resetObjectTimeouts } = require('../../server');
+const { getIP, resetObjectTimeout } = require('../../server');
 
 const EVENT_UPDATE_INTERVAL = 3000; // 3 seconds
 const FULL_UPDATE_INTERVAL = 60000; // 1 minute
@@ -235,7 +235,7 @@ class SceneGraph {
             }
             sceneNode.updateVehicleXYScale(x, y, scale);
             sceneNode.setLocalMatrix(localMatrix);
-            resetObjectTimeouts(objectId);
+            resetObjectTimeout(objectId);
             this.triggerUpdateCallbacks();
             if (this.shouldBroadcastChanges && sceneNode.broadcastRulesSatisfied()) {
                 const updatePositionEvent = SceneGraphEvent.UpdatePosition(id, localMatrix, x, y, scale);

--- a/libraries/sceneGraph/SceneGraph.js
+++ b/libraries/sceneGraph/SceneGraph.js
@@ -2,7 +2,7 @@ let SceneNode = require('./SceneNode');
 let utils = require('./utils');
 const actionSender = require('../utilities').actionSender;
 const { SceneGraphEvent, SceneGraphEventOpEnum, SceneGraphNetworkManager } = require('./SceneGraphNetworking');
-const { getIP } = require('../../server');
+const { getIP, resetObjectTimeouts } = require('../../server');
 
 const EVENT_UPDATE_INTERVAL = 3000; // 3 seconds
 const FULL_UPDATE_INTERVAL = 60000; // 1 minute
@@ -235,6 +235,7 @@ class SceneGraph {
             }
             sceneNode.updateVehicleXYScale(x, y, scale);
             sceneNode.setLocalMatrix(localMatrix);
+            resetObjectTimeouts(objectId);
             this.triggerUpdateCallbacks();
             if (this.shouldBroadcastChanges && sceneNode.broadcastRulesSatisfied()) {
                 const updatePositionEvent = SceneGraphEvent.UpdatePosition(id, localMatrix, x, y, scale);


### PR DESCRIPTION
On a rolling basis, deletes avatar and human objects unless a realtime batchedUpdate or a sceneGraph update references the object within the last (30 or 60) seconds, or unless a keepObjectAlive heartbeat message has been received in the same timeframe.