### PR TITLE
Small adjustments for human objects

### DIFF
--- a/libraries/HumanPoseObject.js
+++ b/libraries/HumanPoseObject.js
@@ -123,7 +123,7 @@ HumanPoseObject.prototype.getFrameKey = function(jointName) {
  */
 HumanPoseObject.prototype.createPoseFrames = function(poseJointSchema) {
     var frames = {};
-    Object.keys(poseJointSchema).forEach(function(jointName) {
+    Object.values(poseJointSchema).forEach(function(jointName) {
         frames[ this.getFrameKey(jointName) ] = this.createFrame(jointName);
     }.bind(this));
     return frames;
@@ -198,6 +198,43 @@ HumanPoseObject.prototype.updateJointPositions = function(joints) {
  */
 HumanPoseObject.getObjectId = function(bodyId) {
     return 'humanPoseObject' + bodyId;
+};
+
+
+/**
+ * Conform to interface of ObjectModel
+ */
+HumanPoseObject.prototype.deconstruct = function() {
+    for (let frameKey in this.frames) {
+        if (typeof this.frames[frameKey].deconstruct === 'function') {
+            this.frames[frameKey].deconstruct();
+        } else {
+            console.warn('Frame exists without proper prototype: ' + frameKey);
+        }
+    }
+};
+
+/**
+ * Conform to interface of ObjectModel
+ * @param {JSON} object
+ */
+HumanPoseObject.prototype.setFromJson = function(object) {
+    Object.assign(this, object);
+    this.setFramesFromJson(object.frames);
+};
+
+/**
+ * Conform to interface of ObjectModel
+ * @param {JSON} frames
+ */
+HumanPoseObject.prototype.setFramesFromJson = function(frames) {
+    this.frames = {};
+    for (var frameKey in frames) {
+        let newFrame = new Frame(this.objectId, frameKey);
+        Object.assign(newFrame, frames[frameKey]);
+        newFrame.setNodesFromJson(frames[frameKey].nodes);
+        this.frames[frameKey] = newFrame;
+    }
 };
 
 module.exports = HumanPoseObject;

--- a/server.js
+++ b/server.js
@@ -1105,7 +1105,7 @@ function startSystem() {
     staleObjectCleaner.createCleanupInterval(avatarCheckIntervalMs, avatarDeletionAgeMs, ['avatar']);
 
     const humanCheckIntervalMs = 5000;
-    const humanDeletionAgeMs = 30000; // human objects are deleted more aggressively if they haven't been seen recently
+    const humanDeletionAgeMs = 15000; // human objects are deleted more aggressively if they haven't been seen recently
     staleObjectCleaner.createCleanupInterval(humanCheckIntervalMs, humanDeletionAgeMs, ['human']);
 
     recorder.initRecorder(objects);


### PR DESCRIPTION
add deconstruct method to human pose objects on server so they can be properly deleted, and shorten life of unobserved pose objects to 15sec.

Also renames the pose joint frames to use the values of the enum, e.g. "nose" rather than the keys of the enum, e.g. "NOSE"