### PR TITLE
Start of objectsPath refactor

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,38 @@
+/**
+ * Server configuration
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const spatialToolboxPath = path.join(os.homedir(), 'Documents', 'spatialToolbox');
+const oldRealityObjectsPath = path.join(os.homedir(), 'Documents', 'realityobjects');
+
+// All objects are stored in this folder:
+// Look for objects in the user Documents directory instead of __dirname+"/objects"
+let objectsPath = spatialToolboxPath;
+
+if (process.env.NODE_ENV === 'test' || os.platform() === 'android' || !fs.existsSync(path.join(os.homedir(), 'Documents'))) {
+    objectsPath = path.join(__dirname, 'spatialToolbox');
+}
+
+// Default back to old realityObjects dir if it exists
+if (!fs.existsSync(objectsPath) &&
+    objectsPath === spatialToolboxPath &&
+    fs.existsSync(oldRealityObjectsPath)) {
+    console.warn('Please rename your realityobjects directory to spatialToolbox');
+    objectsPath = oldRealityObjectsPath;
+}
+
+// create objects folder at objectsPath if necessary
+if (!fs.existsSync(objectsPath)) {
+    console.log('created objects directory at ' + objectsPath);
+    fs.mkdirSync(objectsPath);
+}
+
+module.exports.objectsPath = objectsPath;

--- a/controllers/block.js
+++ b/controllers/block.js
@@ -6,7 +6,6 @@ var objects = {};
 var blockModules;
 var globalVariables;
 var engine;
-var objectsPath;
 
 /**
  * Adds a new block with the provided blockID to the specified node.
@@ -66,7 +65,7 @@ const addNewBlock = function (objectID, frameID, nodeID, blockID, body) {
             reloadNode: {object: objectID, frame: frameID, node: nodeID},
             lastEditor: body.lastEditor
         });
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         console.log('added block: ' + blockID);
         updateStatus = 'added';
@@ -107,7 +106,7 @@ const deleteBlock = function (objectID, frameID, nodeID, blockID, lastEditor) {
             reloadNode: {object: objectID, frame: nodeID, node: nodeID},
             lastEditor: lastEditor
         });
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
         updateStatus = 'deleted: ' + blockID + ' in blocks for object: ' + objectID;
     }
     return updateStatus;
@@ -138,7 +137,7 @@ const postBlockPosition = function (objectID, frameID, nodeID, blockID, body) {
                 foundBlock.x = body.x;
                 foundBlock.y = body.y;
 
-                utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+                utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
                 utilities.actionSender({
                     reloadNode: {object: objectID, frame: frameID, node: nodeID},
                     lastEditor: body.lastEditor
@@ -216,7 +215,6 @@ const setup = function (objects_, blockModules_, globalVariables_, engine_, obje
     blockModules = blockModules_;
     globalVariables = globalVariables_;
     engine = engine_;
-    objectsPath = objectsPath_;
 };
 
 module.exports = {

--- a/controllers/blockLink.js
+++ b/controllers/blockLink.js
@@ -3,7 +3,6 @@ const utilities = require('../libraries/utilities');
 // Variables populated from server.js with setup()
 var objects = {};
 var globalVariables;
-var objectsPath;
 
 /**
  * Adds a new link with the provided linkID to the specified node.
@@ -38,7 +37,7 @@ const addLogicLink = function (objectID, frameID, nodeID, linkID, body) {
             });
             // check if there are new connections associated with the new link.
             // write the object state to the permanent storage.
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
             console.log('added link: ' + linkID);
             updateStatus = 'added';
@@ -60,7 +59,7 @@ const deleteLogicLink = function (objectID, frameID, nodeID, linkID, lastEditor)
             reloadNode: {object: objectID, frame: frameID, node: nodeID},
             lastEditor: lastEditor
         });
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         console.log('deleted link: ' + linkID);
         updateStatus = 'deleted: ' + linkID + ' in logic ' + nodeID + ' in frame: ' + frameID + ' from object: ' + objectID;
@@ -71,7 +70,6 @@ const deleteLogicLink = function (objectID, frameID, nodeID, linkID, lastEditor)
 const setup = function (objects_, globalVariables_, objectsPath_) {
     objects = objects_;
     globalVariables = globalVariables_;
-    objectsPath = objectsPath_;
 };
 
 module.exports = {

--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -10,7 +10,6 @@ var objects = {};
 var globalVariables;
 var hardwareAPI;
 var dirname;
-var objectsPath;
 var identityFolderName;
 var nodeTypeModules;
 var sceneGraph;
@@ -39,7 +38,7 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
             object.frames = {};
         }
 
-        utilities.createFrameFolder(object.name, frame.name, dirname, objectsPath, globalVariables.debug, frame.location);
+        utilities.createFrameFolder(object.name, frame.name, dirname, globalVariables.debug, frame.location);
 
         var newFrame = new Frame(frame.objectId, frameKey);
         newFrame.name = frame.name;
@@ -67,7 +66,7 @@ const addFrameToObject = function (objectKey, frameKey, frame, callback) {
 
         object.frames[frameKey] = newFrame;
 
-        utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
         utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: frame.lastEditor});
 
         sceneGraph.addFrame(objectKey, frameKey, newFrame, newFrame.ar.matrix);
@@ -102,7 +101,7 @@ const generateFrameOnObject = function (objectKey, frameType, relativeMatrix, ca
 
     object.frames[frameKey] = newFrame;
 
-    utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
+    utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
     utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: null});
 
     sceneGraph.addFrame(objectKey, frameKey, newFrame, newFrame.ar.matrix);
@@ -127,7 +126,7 @@ const deletePublicData = function(objectID, frameID, callback) {
         });
 
         // save state to object.json
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         callback(200, {success: true});
     });
@@ -158,7 +157,7 @@ const addPublicData = function(objectID, frameID, body, callback) {
         }
 
         // save state to object.json
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         callback(200, {success: true});
     });
@@ -225,7 +224,7 @@ const copyFrame = function(objectID, frameID, body, callback) {
         newFrame.height = frame.height;
         object.frames[newFrameKey] = newFrame;
 
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         // TODO: by not sending action sender, we assume this is a screen frame -- is that an ok assumption?
         // utilities.actionSender({reloadObject: {object: objectID}, lastEditor: frame.lastEditor});
@@ -266,7 +265,7 @@ const updateFrame = function(objectID, frameID, body, callback) {
         newFrame.setFromJson(frame);
         object.frames[frameID] = newFrame;
 
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         utilities.actionSender({reloadObject: {object: objectID}, lastEditor: body.lastEditor});
 
@@ -310,7 +309,7 @@ const deleteFrame = function(objectId, frameId, body, callback) {
         var urlArray = videoPath.split('/');
 
         var objectName = urlArray[4];
-        var videoDir = utilities.getVideoDir(objectsPath, identityFolderName, globalVariables.isMobile, objectName);
+        var videoDir = utilities.getVideoDir(identityFolderName, globalVariables.isMobile, objectName);
         var videoFilePath = path.join(videoDir, urlArray[6]);
 
         if (fs.existsSync(videoFilePath)) {
@@ -329,7 +328,7 @@ const deleteFrame = function(objectId, frameId, body, callback) {
     delete object.frames[frameId];
 
     // remove the frame directory from the object
-    utilities.deleteFrameFolder(objectName, frameName, objectsPath);
+    utilities.deleteFrameFolder(objectName, frameName);
 
     // Delete frame's nodes // TODO: I don't think this is updated for the current object/frame/node hierarchy
     var deletedNodes = {};
@@ -356,13 +355,13 @@ const deleteFrame = function(objectId, frameId, body, callback) {
         }
 
         if (linkObjectHasChanged) {
-            utilities.writeObjectToFile(objects, linkObjectId, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, linkObjectId, globalVariables.saveToDisk);
             utilities.actionSender({reloadObject: {object: linkObjectId}, lastEditor: body.lastEditor});
         }
     });
 
     // write changes to object.json
-    utilities.writeObjectToFile(objects, objectId, objectsPath, globalVariables.saveToDisk);
+    utilities.writeObjectToFile(objects, objectId, globalVariables.saveToDisk);
     utilities.actionSender({reloadObject: {object: objectId}, lastEditor: body.lastEditor});
 
     sceneGraph.removeElementAndChildren(frameId);
@@ -376,7 +375,7 @@ const setGroup = function(objectID, frameID, body, callback) {
         var newGroupID = body.group;
         if (newGroupID !== frame.groupID) {
             frame.groupID = newGroupID;
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             utilities.actionSender({
                 reloadFrame: {object: objectID, frame: frameID},
                 lastEditor: body.lastEditor
@@ -395,7 +394,7 @@ const setPinned = function(objectID, frameID, body, callback) {
         var newPinned = body.isPinned;
         if (newPinned !== frame.pinned) {
             frame.pinned = newPinned;
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             utilities.actionSender({
                 reloadFrame: {object: objectID, frame: frameID},
                 lastEditor: body.lastEditor
@@ -475,7 +474,7 @@ const changeSize = function (objectID, frameID, nodeID, body, callback) { // esl
         }
 
         if (didUpdate) {
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             utilities.actionSender({
                 reloadFrame: {
                     object: objectID,
@@ -518,7 +517,7 @@ const changeVisualization = function(objectKey, frameKey, body, callback) {
         }
         frame.visualization = newVisualization;
 
-        utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
         callback(200, {success: true});
     } else {
         callback(404, {failure: true, error: 'frame ' + frameKey + ' not found on ' + objectKey});
@@ -540,7 +539,7 @@ const resetPositioning = function(objectID, frameID, callback) {
         scale: 1,
         matrix: []
     };
-    utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+    utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
     callback(200, 'ok');
 };
 
@@ -553,7 +552,6 @@ const setup = function (objects_, globalVariables_, hardwareAPI_, dirname_, obje
     globalVariables = globalVariables_;
     hardwareAPI = hardwareAPI_;
     dirname = dirname_;
-    objectsPath = objectsPath_;
     identityFolderName = identityFolderName_;
     nodeTypeModules = nodeTypeModules_;
     sceneGraph = sceneGraph_;

--- a/controllers/link.js
+++ b/controllers/link.js
@@ -6,7 +6,6 @@ var knownObjects = {};
 var socketArray = {};
 var globalVariables;
 var hardwareAPI;
-var objectsPath;
 var socketUpdater;
 var engine;
 
@@ -97,7 +96,7 @@ const newLink = function (objectID, frameID, linkID, body) {
             foundFrame.links[linkID] = body;
             console.log('added link: ' + linkID);
             // write the object state to the permanent storage.
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
             // check if link is complex data type. If yes trigger engine only for this single link
             if (foundFrame.nodes.hasOwnProperty(body.nodeA)) {
@@ -160,7 +159,7 @@ const deleteLink = function (objectKey, frameKey, linkKey, editorID) {
 
         delete foundFrame.links[linkKey];
 
-        utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
         utilities.actionSender({reloadLink: {object: objectKey, frame: frameKey}, lastEditor: editorID});
 
         // iterate over all frames in all objects to see if the destinationIp is still used by another link after this was deleted
@@ -213,7 +212,7 @@ const addLinkLock = function (objectKey, frameKey, linkKey, body) {
             foundLink.lockType = newLockType;
 
             var object = utilities.getObject(objects, objectKey);
-            utilities.writeObjectToFile(objects, object, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, object, globalVariables.saveToDisk);
             utilities.actionSender({reloadLink: {object: object}});
 
             updateStatus = 'added';
@@ -247,7 +246,7 @@ const deleteLinkLock = function (objectKey, frameKey, linkKey, password) {
             foundLink.lockType = null;
 
             var object = utilities.getObject(objects, objectKey);
-            utilities.writeObjectToFile(objects, object, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, object, globalVariables.saveToDisk);
             utilities.actionSender({reloadLink: {object: objectKey}});
 
             updateStatus = 'deleted';
@@ -264,7 +263,6 @@ const setup = function (objects_, knownObjects_, socketArray_, globalVariables_,
     socketArray = socketArray_;
     globalVariables = globalVariables_;
     hardwareAPI = hardwareAPI_;
-    objectsPath = objectsPath_;
     socketUpdater = socketUpdater_;
     engine = engine_;
 };

--- a/controllers/logicNode.js
+++ b/controllers/logicNode.js
@@ -43,7 +43,7 @@ const addLogicNode = function (objectID, frameID, nodeID, body) {
         newNode.type = 'logic';
 
         // call an action that asks all devices to reload their links, once the links are changed.
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
         utilities.actionSender({
             reloadNode: {object: objectID, frame: frameID, node: nodeID},
             lastEditor: body.lastEditor
@@ -88,7 +88,7 @@ const deleteLogicNode = function (objectID, frameID, nodeID, lastEditor) {
               }
           }*/
 
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
         utilities.actionSender({
             reloadNode: {object: objectID, frame: frameID, node: nodeID},
             lastEditor: lastEditor
@@ -133,7 +133,7 @@ function changeNodeSize(objectID, frameID, nodeID, body, callback) {
 
         // if anything updated, write to disk and broadcast updates to editors
         if (updateStatus === 'ok') {
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             utilities.actionSender({
                 reloadObject: {object: objectID, frame: frameID, node: nodeID},
                 lastEditor: body.lastEditor
@@ -155,7 +155,7 @@ function rename(objectID, frameID, nodeID, body, callback) {
 
         node.name = body.nodeName;
 
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
         callback(200, {success: true});
     });
@@ -224,7 +224,7 @@ function uploadIconImage(objectID, frameID, nodeID, req, callback) {
 
                     if (node) {
                         node.iconImage = 'custom'; //'http://' + object.ip + ':' + serverPort + '/logicNodeIcon/' + object.name + '/' + nodeID + '.jpg';
-                        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+                        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
                         utilities.actionSender({
                             loadLogicIcon: {
                                 object: objectID,

--- a/controllers/node.js
+++ b/controllers/node.js
@@ -4,7 +4,6 @@ const Node = require('../models/Node');
 // Variables populated from server.js with setup()
 var objects = {};
 var globalVariables;
-var objectsPath;
 var sceneGraph;
 
 /**
@@ -42,7 +41,7 @@ const addNodeToFrame = function (objectKey, frameKey, nodeKey, body, callback) {
 
             foundFrame.nodes[nodeKey] = node;
             nodeBody = node;
-            utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
             utilities.actionSender({reloadObject: {object: objectKey}, lastEditor: body.lastEditor});
             sceneGraph.addNode(objectKey, frameKey, nodeKey, node, node.matrix);
 
@@ -88,7 +87,7 @@ const addNodeLock = function (objectKey, frameKey, nodeKey, body) {
             foundNode.lockPassword = newLockPassword;
             foundNode.lockType = newLockType;
 
-            utilities.writeObjectToFile(objects, objectKey, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectKey, globalVariables.saveToDisk);
             utilities.actionSender({reloadNode: {object: objectKey, frame: frameKey, node: nodeKey}});
 
             updateStatus = 'added';
@@ -120,7 +119,7 @@ const deleteNodeLock = function (objectKey, frameKey, nodeKey, password) {
             foundNode.lockType = null;
 
             var object = utilities.getObject(objects, objectKey);
-            utilities.writeObjectToFile(objects, object, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, object, globalVariables.saveToDisk);
             utilities.actionSender({reloadNode: {object: objectKey, frame: frameKey, node: nodeKey}});
 
             updateStatus = 'deleted';
@@ -198,7 +197,7 @@ const changeSize = function (objectID, frameID, nodeID, body, callback) { // esl
         }
 
         if (didUpdate) {
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             utilities.actionSender({
                 reloadFrame: {
                     object: objectID,
@@ -223,7 +222,6 @@ const getNode = function (objectID, frameID, nodeID) {
 const setup = function (objects_, globalVariables_, objectsPath_, sceneGraph_) {
     objects = objects_;
     globalVariables = globalVariables_;
-    objectsPath = objectsPath_;
     sceneGraph = sceneGraph_;
 };
 

--- a/controllers/object.js
+++ b/controllers/object.js
@@ -20,7 +20,7 @@ const uploadVideo = function(objectID, videoID, reqForForm, callback) {
         return;
     }
     try {
-        var videoDir = utilities.getVideoDir(objectsPath, identityFolderName, globalVariables.isMobile, object.name);
+        var videoDir = utilities.getVideoDir(identityFolderName, globalVariables.isMobile, object.name);
 
         var form = new formidable.IncomingForm({
             uploadDir: videoDir,
@@ -159,7 +159,7 @@ const setMatrix = function(objectID, body, callback) {
     }
 
     if (object.type !== 'avatar') {
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
     }
 
     sceneGraph.updateWithPositionData(objectID, null, null, object.matrix);
@@ -217,7 +217,7 @@ const memoryUpload = function(objectID, req, callback) {
             obj.memoryCameraMatrix = JSON.parse(fields.memoryCameraInfo);
             obj.memoryProjectionMatrix = JSON.parse(fields.memoryProjectionInfo);
 
-            utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+            utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             utilities.actionSender({loadMemory: {object: objectID, ip: obj.ip}});
         }
 
@@ -230,7 +230,7 @@ const memoryUpload = function(objectID, req, callback) {
 const deactivate = function(objectID, callback) {
     try {
         utilities.getObject(objects, objectID).deactivated = true;
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
         sceneGraph.deactivateElement(objectID);
         callback(200, 'ok');
     } catch (e) {
@@ -241,7 +241,7 @@ const deactivate = function(objectID, callback) {
 const activate = function(objectID, callback) {
     try {
         utilities.getObject(objects, objectID).deactivated = false;
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
         sceneGraph.activateElement(objectID);
         callback(200, 'ok');
     } catch (e) {
@@ -256,7 +256,7 @@ const setVisualization = function(objectID, vis, callback) {
     }
     try {
         object.visualization = vis;
-        utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+        utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
         callback(200, 'ok');
     } catch (e) {
         callback(500, {success: false, error: e.message});
@@ -329,7 +329,7 @@ const generateXml = function(objectID, body, callback) {
             if (object) {
                 object.targetSize.width = parseFloat(msgObject.width);
                 object.targetSize.height = parseFloat(msgObject.height);
-                utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+                utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
             }
         }
     });

--- a/libraries/gitInterface.js
+++ b/libraries/gitInterface.js
@@ -5,20 +5,10 @@ const root = require('../getAppRootFolder');
 
 var utilities = require('./utilities');
 var identityFile = '/.identity/object.json';
-let homeDirectory = path.join(os.homedir(), 'Documents', 'spatialToolbox');
-const oldHomeDirectory = path.join(os.homedir(), 'Documents', 'realityobjects');
 
-// Default back to old realityObjects dir if it exists
-if (!fs.existsSync(homeDirectory) &&
-    fs.existsSync(oldHomeDirectory)) {
-    homeDirectory = oldHomeDirectory;
-}
+const {objectsPath} = require('../config.js');
 
-if (process.env.NODE_ENV === 'test' || os.platform() === 'android' || !fs.existsSync(path.join(os.homedir(), 'Documents'))) {
-    homeDirectory = path.join(root, 'spatialToolbox');
-}
-
-const git = require('simple-git')(homeDirectory);
+const git = require('simple-git')(objectsPath);
 
 function saveCommit(object, objects, callback) {
     console.log('git saveCommit');
@@ -28,7 +18,7 @@ function saveCommit(object, objects, callback) {
         object.framesHistory = JSON.parse(JSON.stringify(object.frames));
 
         // todo; replace with a try-catch ?
-        utilities.writeObjectToFile(objects, object.objectId, homeDirectory, true);
+        utilities.writeObjectToFile(objects, object.objectId, true);
 
         git.checkIsRepo(function (err) {
             if (err) {

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -32,7 +32,7 @@ var knownObjects; // needed to check if sockets are still used when we delete li
 var socketArray; // needed to delete sockets when links are removed
 var globalVariables;
 var dirnameO;
-var objectsPath;
+const {objectsPath} = require('../config.js');
 var nodeTypeModules;
 // eslint-disable-next-line no-unused-vars
 var blockModules;
@@ -40,7 +40,7 @@ var services;
 var version;
 var protocol;
 var serverPort;
-var callback;
+let dataCallback;
 var actionCallback;
 var publicDataCallBack;
 var writeObjectCallback;
@@ -115,7 +115,7 @@ exports.write = function (object, tool, node, value, mode, unit, unitMin, unitMa
                 thisData.unitMin = unitMin;
                 thisData.unitMax = unitMax;
                 //callback is objectEngine in server.js. Notify data has changed.
-                callback(objectKey, frameUuid, nodeUuid, thisData, objects, nodeTypeModules);
+                dataCallback(objectKey, frameUuid, nodeUuid, thisData, objects, nodeTypeModules);
             }
         }
     }
@@ -893,7 +893,6 @@ exports.setup = function setup(objects_, objectLookup_, knownObjects_,
     socketArray = socketArray_;
     globalVariables = globalVariables_;
     dirnameO = dirnameO_;
-    objectsPath = objectsPath_;
     nodeTypeModules = nodeTypeModules_;
     blockModules = blockModules_;
     services = services_;
@@ -902,7 +901,7 @@ exports.setup = function setup(objects_, objectLookup_, knownObjects_,
     serverPort = serverPort_;
     publicDataCallBack = hardwareAPICallbacks.publicData;
     actionCallback = hardwareAPICallbacks.actions;
-    callback = hardwareAPICallbacks.data;
+    dataCallback = hardwareAPICallbacks.data;
     writeObjectCallback = hardwareAPICallbacks.write;
     sceneGraphReference = sceneGraphReference_;
     worldGraphReference = worldGraphReference_;

--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -143,7 +143,7 @@ exports.writePublicData = function (object, tool, node, dataObject, data) {
  * @param {string} type The name of your hardware interface (i.e. what you put in the type parameter of addIO())
  **/
 exports.clearObject = function (objectUuid, toolUuid) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(objectUuid, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(objectUuid);
     if (objectID && objects[objectID] && objects[objectID].frames &&
         objects[objectID].frames[objectID] &&
         objects[objectID].frames[objectID].nodes) {
@@ -164,7 +164,7 @@ exports.clearObject = function (objectUuid, toolUuid) {
 };
 
 exports.removeAllNodes = function (object, tool) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     var frameID = objectID + tool;
     if (objectID) {
         if (objects.hasOwnProperty(objectID)) {
@@ -231,7 +231,7 @@ var deleteLinksToAndFromNode = function (objectUuid, toolUuid, nodeUuid) {
 };
 
 exports.reloadNodeUI = function (object) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     actionCallback({reloadObject: {object: objectID}});
     writeObjectCallback(objectID);
 };
@@ -300,7 +300,7 @@ exports.getAllTools = getAllTools_;
 exports.getAllFrames = getAllTools_;
 
 exports.getAllNodes = function (object, tool) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     var frameID = objectID + tool;
 
     // lookup object properties using name
@@ -319,7 +319,7 @@ exports.getAllNodes = function (object, tool) {
 };
 
 exports.getAllLinksToNodes = function (object, tool) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     var frameID = objectID + tool;
 
     // lookup object properties using name
@@ -413,7 +413,7 @@ exports.actionSender = function (action, timeToLive, beatport) {
 
 
 exports.clearTool = function (object, tool) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     console.log('remove set tool');
 
     var frameUuid = objectID + tool;
@@ -431,7 +431,7 @@ exports.clearTool = function (object, tool) {
 
 exports.setTool = function (object, tool, newTool, dirName) {
 
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     console.log('set new tool: ', newTool);
 
     var frameUuid = objectID + tool;
@@ -481,8 +481,8 @@ exports.setTool = function (object, tool, newTool, dirName) {
  **/
 
 exports.addNode = function (object, tool, node, type, position) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
-    console.log('hardwareInterfaces.addNode objectID: ', objectID, object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
+    console.log('hardwareInterfaces.addNode objectID: ', objectID, object);
 
     if (!objectID) {
         console.log('Creating new object for hardware node', object);
@@ -492,7 +492,7 @@ exports.addNode = function (object, tool, node, type, position) {
         var jsonFilePath = path.join(identityPath, 'object.json');
         objectID = object + utilities.uuidTime();
 
-        utilities.createFolder(object, objectsPath, globalVariables.debug);
+        utilities.createFolder(object, globalVariables.debug);
 
         // create a new anchor object
         objects[objectID] = new ObjectModel(services.ip, version, protocol, objectID);
@@ -533,9 +533,9 @@ exports.addNode = function (object, tool, node, type, position) {
 
             if (!objects[objectID].frames.hasOwnProperty(frameUuid)) {
                 objects[objectID].frames[frameUuid] = new Frame(objectID, frameUuid);
-                utilities.createFrameFolder(object, tool, dirnameO, objectsPath, globalVariables.debug, 'local');
+                utilities.createFrameFolder(object, tool, dirnameO, globalVariables.debug, 'local');
             } else {
-                utilities.createFrameFolder(object, tool, dirnameO, objectsPath, globalVariables.debug, objects[objectID].frames[frameUuid].location);
+                utilities.createFrameFolder(object, tool, dirnameO, globalVariables.debug, objects[objectID].frames[frameUuid].location);
             }
             if (!objects[objectID].frames[frameUuid].hasOwnProperty('nodes')) {
                 objects[objectID].frames[frameUuid].nodes = {};
@@ -581,7 +581,7 @@ exports.addNode = function (object, tool, node, type, position) {
 };
 
 exports.renameNode = function (object, tool, oldNode, newNode) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     if (objectID) {
         if (objects.hasOwnProperty(objectID)) {
             var frameUUID = objectID + tool;
@@ -613,7 +613,7 @@ exports.moveNode = function (object, tool, node, x, y, scale, matrix, loyalty) {
     if (loyalty !== undefined) thisLoyalty = 'object';
 
 
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     var frameID = objectID + tool;
     var nodeID = objectID + tool + node;
 
@@ -640,7 +640,7 @@ exports.moveNode = function (object, tool, node, x, y, scale, matrix, loyalty) {
 };
 
 exports.removeNode = function (object, tool, node) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     var frameID = objectID + tool;
     var nodeID = objectID + tool + node;
     if (objectID) {
@@ -662,7 +662,7 @@ exports.removeNode = function (object, tool, node) {
 };
 
 exports.attachNodeToGroundPlane = function (object, tool, node, shouldAttachToGroundPlane) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     var frameID = objectID + tool;
     var nodeID = objectID + tool + node;
 
@@ -680,12 +680,12 @@ exports.attachNodeToGroundPlane = function (object, tool, node, shouldAttachToGr
 };
 
 exports.pushUpdatesToDevices = function (object) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     actionCallback({reloadObject: {object: objectID}});
 };
 
 exports.generateFrame = function (objectName, frameType, relativeMatrix) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(objectName, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(objectName);
     console.log('hardwareInterfaces.generateFrame on object ' + objectID);
 
     if (!objectID || !objects.hasOwnProperty(objectID)) {
@@ -713,7 +713,7 @@ exports.generateFrame = function (objectName, frameType, relativeMatrix) {
 
     console.log('generated frame of type ' + frameType + ' on object ' + objectID);
 
-    utilities.writeObjectToFile(objects, objectID, objectsPath, globalVariables.saveToDisk);
+    utilities.writeObjectToFile(objects, objectID, globalVariables.saveToDisk);
 
     // sceneGraph.addFrame(objectKey, frameKey, newFrame, newFrame.ar.matrix);
 
@@ -726,7 +726,7 @@ exports.generateFrame = function (objectName, frameType, relativeMatrix) {
 };
 
 exports.activate = function (object) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     if (objectID) {
         if (objects.hasOwnProperty(objectID)) {
             objects[objectID].deactivated = false;
@@ -735,7 +735,7 @@ exports.activate = function (object) {
 };
 
 exports.deactivate = function (object) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     console.log('hardwareInterfaces.deactivate');
     if (objectID) {
         if (objects.hasOwnProperty(objectID)) {
@@ -746,7 +746,7 @@ exports.deactivate = function (object) {
 };
 
 exports.hasTool = function(object, tool) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     if (objectID) {
         if (objects.hasOwnProperty(objectID)) {
             let toolId = objectID + tool;
@@ -757,7 +757,7 @@ exports.hasTool = function(object, tool) {
 };
 
 exports.getObjectIdFromObjectName = function (object) {
-    return utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    return utilities.getObjectIdFromTargetOrObjectFile(object);
 };
 
 exports.getObjectNameFromObjectId = function (objectId) {
@@ -793,7 +793,7 @@ exports.getWorldObjectForObject = function (objectId) {
 
 exports.getMarkerSize = function (object) {
     try {
-        var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+        var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
         return objects[objectID].targetSize;
     } catch (e) {
         console.warn('Cannot get markerSize for ' + object + ', returning (0,0)');
@@ -807,7 +807,7 @@ exports.getMarkerSize = function (object) {
  * @param {number} height - target size height in mm
  */
 exports.setMarkerSize = function (object, width, height) {
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     if (objects.hasOwnProperty(objectID)) {
         console.log('old size = ' + objects[objectID].targetSize);
 
@@ -824,7 +824,7 @@ exports.setMarkerSize = function (object, width, height) {
 exports.setObjectVisualization = function (object, visualization) {
     if (visualization !== 'screen' && visualization !== 'ar') { return; } // only supported types
 
-    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object, objectsPath);
+    var objectID = utilities.getObjectIdFromTargetOrObjectFile(object);
     objectController.setVisualization(objectID, visualization, function (statusCode, _responseContents) {
         if (statusCode === 200) {
             console.log('set visualization for ' + object + ' to ' + visualization + ' from hardware interface');

--- a/libraries/nodeUtilities.js
+++ b/libraries/nodeUtilities.js
@@ -4,20 +4,10 @@ var linkController;
 // Pointers populated from server.js with setup()
 var objects = {};
 var sceneGraph = {};
-var knownObjects = {};
-var socketArray = {};
-var globalVariables = {};
-var hardwareAPI = {};
-var objectsPath = {};
 
-exports.setup = function (_objects, _sceneGraph, _knownObjects, _socketArray, _globalVariables, _hardwareAPI, _objectsPath, _linkController) {
+exports.setup = function (_objects, _sceneGraph, _knownObjects, _socketArray, _globalVariables, _hardwareAPI, objectsPath, _linkController) {
     objects = _objects;
     sceneGraph = _sceneGraph;
-    knownObjects = _knownObjects;
-    socketArray = _socketArray;
-    globalVariables = _globalVariables;
-    hardwareAPI = _hardwareAPI;
-    objectsPath = _objectsPath;
     linkController = _linkController;
 };
 
@@ -26,7 +16,7 @@ exports.deepCopy = utilities.deepCopy;
 exports.searchNodeByType = function (nodeType, _object, tool, node, callback) {
     let thisObjectKey = _object;
     if (!(_object in objects)) {
-        thisObjectKey = utilities.getObjectIdFromTargetOrObjectFile(_object, objectsPath);
+        thisObjectKey = utilities.getObjectIdFromTargetOrObjectFile(_object);
     }
     let thisObject = utilities.getObject(objects, thisObjectKey);
     if (!tool && !node) {

--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -126,7 +126,7 @@ exports.printFolder = function (objects, objectsPath, debug, objectInterfaceName
     tempFiles.forEach(function(objectKey) {
 
         var thisObjectKey = objectKey;
-        var tempKey = utilities.getObjectIdFromTargetOrObjectFile(objectKey, objectsPath); // gets the object id from the xml target file
+        var tempKey = utilities.getObjectIdFromTargetOrObjectFile(objectKey); // gets the object id from the xml target file
         if (tempKey) {
             thisObjectKey = tempKey;
         }


### PR DESCRIPTION
In a perfect world, every injection of objectsPath (and other shared variables) is done by requiring a file so we don't have error-prone calls to setup(every, variable, in, server, dot, js) but it's not really a high priority to fix this considering the server currently works