### PR TITLE
Drop forced nulling of context and domElement

### DIFF
--- a/libraries/objectDefaultFiles/gl-worker.js
+++ b/libraries/objectDefaultFiles/gl-worker.js
@@ -453,8 +453,6 @@ class ThreejsInterface {
                     proxies = [];
                     this.realRenderer.dispose();
                     this.realRenderer.forceContextLoss();
-                    this.realRenderer.context = null;
-                    this.realRenderer.domElement = null;
                     this.realRenderer = null;
                     // eslint-disable-next-line no-global-assign
                     realGl = null;


### PR DESCRIPTION
On some versions of three.js this raises an error and it shouldn't be necessary given that we're dropping the overall reference to realRenderer