### PR TITLE
Persist recorder log on exit instead of on sigint

### DIFF
--- a/libraries/recorder.js
+++ b/libraries/recorder.js
@@ -91,8 +91,7 @@ recorder.getCurrentLogName = function() {
     return 'objects_' + timeString + '.json';
 };
 
-recorder.getAndGuaranteeOutputFilename = function() {
-    const logName = recorder.getCurrentLogName();
+recorder.getAndGuaranteeOutputFilename = function(logName) {
     const outputFilename = path.join(logsPath, logName + '.gz');
 
     if (!fs.existsSync(logsPath)) {
@@ -103,6 +102,7 @@ recorder.getAndGuaranteeOutputFilename = function() {
 };
 
 recorder.persistToFile = function () {
+    let logName = recorder.getCurrentLogName();
     let timeObjectStr = JSON.stringify(recorder.timeObject);
     recorder.objectOld = {};
     recorder.timeObject = {};
@@ -110,7 +110,7 @@ recorder.persistToFile = function () {
     return new Promise((resolve, reject) => {
         let outputFilename;
         try {
-            outputFilename = recorder.getAndGuaranteeOutputFilename();
+            outputFilename = recorder.getAndGuaranteeOutputFilename(logName);
         } catch (err) {
             console.error('Log dir creation failed', err);
             reject(err);
@@ -136,11 +136,12 @@ recorder.persistToFile = function () {
 };
 
 recorder.persistToFileSync = function() {
+    let logName = recorder.getCurrentLogName();
     let timeObjectStr = JSON.stringify(recorder.timeObject);
     recorder.objectOld = {};
     recorder.timeObject = {};
 
-    let outputFilename = recorder.getAndGuaranteeOutputFilename();
+    let outputFilename = recorder.getAndGuaranteeOutputFilename(logName);
 
     const buffer = zlib.gzipSync(timeObjectStr);
     fs.writeFileSync(outputFilename, buffer);

--- a/routers/history.js
+++ b/routers/history.js
@@ -11,21 +11,26 @@ const router = express.Router();
 let patches = [];
 
 router.get('/logs', function(req, res) {
-    fs.readdir(recorder.logsPath, function (err, files) {
-        if (err) {
-            res.json([]);
-            return;
-        }
-        const logNames = {};
-        for (let file of files) {
-            if (file.endsWith('.json.gz')) {
-                let jsonLogName = file.split('.')[0] + '.json';
-                logNames[jsonLogName] = true;
+    if (fs.existsSync(recorder.logsPath)) {
+        fs.readdir(recorder.logsPath, function (err, files) {
+            if (err) {
+                console.log('blargl err', err);
+                res.json([]);
+                return;
             }
-        }
-        logNames[recorder.getCurrentLogName()] = true;
-        res.json(Object.keys(logNames));
-    });
+            const logNames = {};
+            for (let file of files) {
+                if (file.endsWith('.json.gz')) {
+                    let jsonLogName = file.split('.')[0] + '.json';
+                    logNames[jsonLogName] = true;
+                }
+            }
+            logNames[recorder.getCurrentLogName()] = true;
+            res.json(Object.keys(logNames));
+        });
+    } else {
+        res.json([recorder.getCurrentLogName()]);
+    }
 });
 
 /**

--- a/server.js
+++ b/server.js
@@ -1096,17 +1096,15 @@ function startSystem() {
 
 async function exit() {
     hardwareAPI.shutdown();
-
-    try {
-        await recorder.stop();
-    } catch (err) {
-        console.error('Recorder error', err);
-    }
-
     process.exit();
 }
 
 process.on('SIGINT', exit);
+
+process.on('exit', function() {
+    // Always, even when crashing, try to persist the recorder log
+    recorder.persistToFileSync();
+});
 
 if (process.pid) {
     console.log('Reality Server server.js process is running with PID ' + process.pid);


### PR DESCRIPTION
Running in the exit handler requires a synchronous persist function. PR also changes the behavior of the asynchronous version to never skip updates. Both this new approach and the old approach will lose data in the event of a compression/write error