### PR TITLE
adds new DELETE /object/${objectID} route for manager to use

### DIFF
--- a/controllers/object.js
+++ b/controllers/object.js
@@ -12,6 +12,35 @@ var objectsPath;
 var identityFolderName;
 var git;
 var sceneGraph;
+// needed for deleteObject
+let objectLookup;
+let activeHeartbeats;
+let knownObjects;
+let setAnchors;
+
+const deleteObject = function(objectID) {
+    let object = utilities.getObject(objects, objectID);
+    if (!object) {
+        return {
+            status: 404,
+            error: `Object ${objectID} not found`
+        }
+    }
+
+    try {
+        utilities.deleteObject(object.name, objects, objectLookup, activeHeartbeats, knownObjects, sceneGraph, setAnchors)
+    } catch (e) {
+        return {
+            status: 500,
+            error: `Error deleting object ${objectID}`
+        }
+    }
+
+    return {
+        status: 200,
+        message: `Deleted object ${objectID}`
+    }
+}
 
 const uploadVideo = function(objectID, videoID, reqForForm, callback) {
     let object = utilities.getObject(objects, objectID);
@@ -370,7 +399,8 @@ const getObject = function (objectID, excludeUnpinned) {
     return filteredObject;
 };
 
-const setup = function (objects_, globalVariables_, hardwareAPI_, objectsPath_, identityFolderName_, git_, sceneGraph_) {
+const setup = function (objects_, globalVariables_, hardwareAPI_, objectsPath_, identityFolderName_, git_, sceneGraph_,
+    objectLookup_, activeHeartbeats_, knownObjects_, setAnchors_) {
     objects = objects_;
     globalVariables = globalVariables_;
     hardwareAPI = hardwareAPI_;
@@ -378,9 +408,14 @@ const setup = function (objects_, globalVariables_, hardwareAPI_, objectsPath_, 
     identityFolderName = identityFolderName_;
     git = git_;
     sceneGraph = sceneGraph_;
+    objectLookup = objectLookup_;
+    activeHeartbeats = activeHeartbeats_;
+    knownObjects = knownObjects_;
+    setAnchors = setAnchors_;
 };
 
 module.exports = {
+    deleteObject: deleteObject,
     uploadVideo: uploadVideo,
     uploadMediaFile: uploadMediaFile,
     saveCommit: saveCommit,

--- a/controllers/object.js
+++ b/controllers/object.js
@@ -38,6 +38,7 @@ const deleteObject = function(objectID) {
 
     return {
         status: 200,
+        success: true,
         message: `Deleted object ${objectID}`
     }
 }

--- a/controllers/object.js
+++ b/controllers/object.js
@@ -24,24 +24,24 @@ const deleteObject = function(objectID) {
         return {
             status: 404,
             error: `Object ${objectID} not found`
-        }
+        };
     }
 
     try {
-        utilities.deleteObject(object.name, objects, objectLookup, activeHeartbeats, knownObjects, sceneGraph, setAnchors)
+        utilities.deleteObject(object.name, objects, objectLookup, activeHeartbeats, knownObjects, sceneGraph, setAnchors);
     } catch (e) {
         return {
             status: 500,
             error: `Error deleting object ${objectID}`
-        }
+        };
     }
 
     return {
         status: 200,
         success: true,
         message: `Deleted object ${objectID}`
-    }
-}
+    };
+};
 
 const uploadVideo = function(objectID, videoID, reqForForm, callback) {
     let object = utilities.getObject(objects, objectID);

--- a/routers/object.js
+++ b/routers/object.js
@@ -10,6 +10,14 @@ const logicNodeController = require('../controllers/logicNode.js');
 const nodeController = require('../controllers/node.js');
 const objectController = require('../controllers/object.js');
 
+router.delete('/:object', (req, res) => {
+    if (!utilities.isValidId(req.params.object)) {
+        res.status(400).send('Invalid object id. Must be alphanumeric.');
+        return;
+    }
+    res.send(objectController.deleteObject(req.params.object));
+});
+
 // logic links
 router.post('/:objectName/frame/:frameName/node/:nodeName/link/:linkName/addBlockLink/', function (req, res) {
     if (!utilities.isValidId(req.params.objectName) || !utilities.isValidId(req.params.frameName) || !utilities.isValidId(req.params.nodeName) || !utilities.isValidId(req.params.linkName)) {

--- a/server.js
+++ b/server.js
@@ -4592,7 +4592,7 @@ function setupControllers() {
     linkController.setup(objects, knownObjects, socketArray, globalVariables, hardwareAPI, objectsPath, socketUpdater, engine);
     logicNodeController.setup(objects, globalVariables, objectsPath, identityFolderName, Jimp);
     nodeController.setup(objects, globalVariables, objectsPath, sceneGraph);
-    objectController.setup(objects, globalVariables, hardwareAPI, objectsPath, identityFolderName, git, sceneGraph);
+    objectController.setup(objects, globalVariables, hardwareAPI, objectsPath, identityFolderName, git, sceneGraph, objectLookup, activeHeartbeats, knownObjects, setAnchors);
     spatialController.setup(objects, globalVariables, hardwareAPI, sceneGraph);
 }
 

--- a/server.js
+++ b/server.js
@@ -2594,6 +2594,9 @@ function objectWebServer() {
 
                 res.send('ok');
             }
+
+            // deprecated route for deleting objects or frames
+            // check routers/object.js for DELETE /object/objectKey and DELETE /object/objectKey/frames/frameKey
             if (req.body.action === 'delete') {
 
                 var deleteFolderRecursive = function (folderDel) {


### PR DESCRIPTION
Deprecates the old way to delete objects, which was with:

POST /
{
  action: 'delete',
  name: `${object.name}`,
  frame: ''
}

You can now delete an object with:

DELETE `/object/${objectID}`

This is consistent with how to delete frames (tools), which is currently done with:

DELETE `/object/${objectID}/frames/${frameID}`