### PR TITLE
increase avatar deletion age back up to 15s; 5s led to some accidental deletions

### DIFF
--- a/server.js
+++ b/server.js
@@ -1078,7 +1078,7 @@ function startSystem() {
 
     // checks if any avatar or humanPose objects haven't been updated in awhile, and deletes them
     const avatarCheckIntervalMs = 5000; // how often to check if avatar objects are inactive
-    const avatarDeletionAgeMs = 5000; // how long an avatar object can stale be before being deleted
+    const avatarDeletionAgeMs = 15000; // how long an avatar object can stale be before being deleted
     staleObjectCleaner.createCleanupInterval(avatarCheckIntervalMs, avatarDeletionAgeMs, ['avatar']);
 
     const humanCheckIntervalMs = 5000;


### PR DESCRIPTION
If the app hangs for too long your own avatar could be deleted by your server, causing your cursor and presence to disappear. No mechanism to re-establish it yet if it gets deleted, so I'm giving it a more generous time buffer to minimize these instances for now.