### PR TITLE
prevent app crash if object deleted while write pending

### DIFF
--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -382,6 +382,11 @@ function executeWrite(objects) {
     let obj = firstKey;
     delete writeBufferList[firstKey];
 
+    if (!objects[obj]) { // if object was deleted while write is pending
+        isWriting = false;
+        return;
+    }
+
     // prepare to write
     var outputFilename = objectsPathBuffered + '/' + objects[obj].name + '/' + identityFolderName + '/object.json';
     var objectData = objects[obj];


### PR DESCRIPTION
A proposed solution to the crash log that happened to me:

```
2023-03-07T20:22:25.551Z - debug: received /disconnectEditor with editorId: zY1mptc8 
2023-03-07T20:22:25.552Z - debug: delete avatar objects associated with zY1mptc8 
2023-03-07T20:22:25.552Z - debug: Deleting object: _AVATAR_zY1mptc8_desktop 
2023-03-07T20:22:25.558Z - debug: i deleted: _AVATAR_zY1mptc8_desktop_f45h0at3qgi 
Downloading started
2023-03-07T20:22:25.572Z - debug: delete human pose objects associated with zY1mptc8 
/private/var/containers/Bundle/Application/BA52829A-94DF-476D-BAA6-FFDFEF551ED7/Vuforia Spatial Toolbox.app/vuforia-spatial-edge-server/libraries/utilities.js:386
    var outputFilename = objectsPathBuffered + '/' + objects[obj].name + '/' + identityFolderName + '/object.json';
                                                                  ^

TypeError: Cannot read property 'name' of undefined
    at executeWrite (/private/var/containers/Bundle/Application/BA52829A-94DF-476D-BAA6-FFDFEF551ED7/Vuforia Spatial Toolbox.app/vuforia-spatial-edge-server/libraries/utilities.js:386:67)
    at /private/var/containers/Bundle/Application/BA52829A-94DF-476D-BAA6-FFDFEF551ED7/Vuforia Spatial Toolbox.app/vuforia-spatial-edge-server/libraries/utilities.js:393:9
    at /private/var/containers/Bundle/Application/BA52829A-94DF-476D-BAA6-FFDFEF551ED7/Vuforia Spatial Toolbox.app/vuforia-spatial-edge-server/node_modules/graceful-fs/graceful-fs.js:61:14
    at FSReqCallback.oncomplete (fs.js:156:23)
```