### PR TITLE
adds onWindowResized tool API

### DIFF
--- a/libraries/objectDefaultFiles/envelope.js
+++ b/libraries/objectDefaultFiles/envelope.js
@@ -183,8 +183,7 @@
         this.realityInterface.sendCreateNode(params.name, params.x, params.y, params.groundplane, params.type, params.noDuplicate);
         realityInterface.addReadListener('open', this._defaultOpenNodeListener.bind(this));
 
-        // this adjusts the size of the body to be fullscreen based on accurate device screen size
-        realityInterface.getScreenDimensions(function(width, height) {
+        const adjustForScreenSize = (width, height) => {
             this.screenDimensions = {
                 width: width,
                 height: height
@@ -194,7 +193,14 @@
             // if necessary, reposition/resize any element with manual adjustments
             rootElementWhenOpen.style.width = width + 'px';
             rootElementWhenOpen.style.height = height + 'px';
-        }.bind(this));
+        }
+
+        // this adjusts the size of the body to be fullscreen based on accurate device screen size
+        realityInterface.getScreenDimensions(adjustForScreenSize);
+
+        realityInterface.onWindowResized(({width, height})=> {
+            adjustForScreenSize(width, height);
+        });
 
         // Manage the UI for open and closed states
         this.rootElementWhenOpen = rootElementWhenOpen;

--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -717,6 +717,7 @@
                 this.ignoreAllTouches = makeSendStub('ignoreAllTouches');
                 this.changeFrameSize = makeSendStub('changeFrameSize');
                 this.changeToolSize = makeSendStub('changeToolSize');
+                this.onWindowResized = makeSendStub('onWindowResized');
                 this.prefersAttachingToWorld = makeSendStub('prefersAttachingToWorld');
                 this.prefersAttachingToObjects = makeSendStub('prefersAttachingToObjects');
                 this.subscribeToWorldId = makeSendStub('subscribeToWorldId');
@@ -1958,6 +1959,22 @@
         };
 
         this.changeToolSize = this.changeFrameSize;
+
+        let windowResizedCallbackCount = 0;
+        this.onWindowResized = function(callback) {
+            windowResizedCallbackCount++;
+            spatialObject.messageCallBacks[`onWindowResizedCall${windowResizedCallbackCount}`] = (msgContent) => {
+                if (typeof msgContent.onWindowResized === 'undefined') return;
+                callback({
+                    width: msgContent.onWindowResized.width,
+                    height: msgContent.onWindowResized.height
+                });
+            }
+
+            postDataToParent({
+                sendWindowResize: true
+            });
+        }
 
         /**
          * Asynchronously query the screen width and height from the parent application, as the iframe itself can't access that


### PR DESCRIPTION
Action item: for our three.js tools, add code along these lines to make everything render correctly in response to the API:

```
    spatialInterface.onWindowResized(({width, height}) => {
        console.log('onWindowResized');
        mainData.width = width;
        mainData.height = height;
        rendererWidth = width;
        rendererHeight = height;
        aspectRatio = rendererWidth / rendererHeight;
        renderer.setSize(rendererWidth, rendererHeight);
        realRenderer.setSize(rendererWidth, rendererHeight);
        isProjectionMatrixSet = false;
        spatialInterface.subscribeToMatrix(); // this should trigger a new retrieval of the projectionMatrix
    });
```

Requires: https://github.com/ptcrealitylab/vuforia-spatial-toolbox-userinterface/pull/388