### PR TITLE
Make server work on non-UDP-compatible networks

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,8 @@ const oldRealityObjectsPath = path.join(os.homedir(), 'Documents', 'realityobjec
 // Look for objects in the user Documents directory instead of __dirname+"/objects"
 let objectsPath = spatialToolboxPath;
 
+const SIMULATE_CELLULAR_NETWORK = true;
+
 if (process.env.NODE_ENV === 'test' || os.platform() === 'android' || !fs.existsSync(path.join(os.homedir(), 'Documents'))) {
     objectsPath = path.join(__dirname, 'spatialToolbox');
 }
@@ -36,3 +38,4 @@ if (!fs.existsSync(objectsPath)) {
 }
 
 module.exports.objectsPath = objectsPath;
+module.exports.SIMULATE_CELLULAR_NETWORK = SIMULATE_CELLULAR_NETWORK;

--- a/config.js
+++ b/config.js
@@ -17,8 +17,6 @@ const oldRealityObjectsPath = path.join(os.homedir(), 'Documents', 'realityobjec
 // Look for objects in the user Documents directory instead of __dirname+"/objects"
 let objectsPath = spatialToolboxPath;
 
-const SIMULATE_CELLULAR_NETWORK = true;
-
 if (process.env.NODE_ENV === 'test' || os.platform() === 'android' || !fs.existsSync(path.join(os.homedir(), 'Documents'))) {
     objectsPath = path.join(__dirname, 'spatialToolbox');
 }
@@ -38,4 +36,3 @@ if (!fs.existsSync(objectsPath)) {
 }
 
 module.exports.objectsPath = objectsPath;
-module.exports.SIMULATE_CELLULAR_NETWORK = SIMULATE_CELLULAR_NETWORK;

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -77,8 +77,7 @@ let socketReferences = {
 let ioReference = null;
 
 let callbacks = {
-    triggerUDPCallbacks: null,
-    triggerSocketIoCallbacks: null
+    triggerUDPCallbacks: null
 };
 
 exports.setup = function(_socketReferences, _ioReference, _callbacks) {

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -73,12 +73,17 @@ var hardwareIdentity = path.join(objectsPath, identityFolderName);
 let socketReferences = {
     realityEditorUpdateSocketArray: null
 };
+
+let ioReference = null;
+
 let callbacks = {
-    triggerUDPCallbacks: null
+    triggerUDPCallbacks: null,
+    triggerSocketIoCallbacks: null
 };
 
-exports.setup = function(_socketReferences, _callbacks) {
+exports.setup = function(_socketReferences, _ioReference, _callbacks) {
     socketReferences = _socketReferences;
+    ioReference = _ioReference;
     callbacks = _callbacks;
 };
 
@@ -793,7 +798,7 @@ function sendWithFallback(client, PORT, HOST, messageObject, options = {closeAft
                     for (let thisEditor in socketReferences.realityEditorUpdateSocketArray) {
                         let messageName = isActionMessage ? '/udp/action' : '/udp/beat';
                         // console.log(`sending ${messageName} over websocket ${thisEditor} instead of UDP message`);
-                        io.sockets.connected[thisEditor].emit(messageName, JSON.stringify(messageObject));
+                        ioReference.sockets.connected[thisEditor].emit(messageName, JSON.stringify(messageObject));
                     }
 
                     // send to cloud-proxied clients and other subscribing modules

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -62,7 +62,7 @@ const path = require('path');
 const request = require('request');
 const fetch = require('node-fetch');
 const ObjectModel = require('../models/ObjectModel.js');
-const {objectsPath} = require('../config.js');
+const {objectsPath, SIMULATE_CELLULAR_NETWORK} = require('../config.js');
 
 const hardwareInterfaces = {};
 
@@ -727,6 +727,11 @@ exports.actionSender = function actionSender(action, timeToLive, beatport) {
     if (!timeToLive) timeToLive = 2;
     if (!beatport) beatport = 52316;
     //  console.log(action);
+    
+    if (SIMULATE_CELLULAR_NETWORK) {
+        console.warn('SIMULATE_CELLULAR_NETWORK=true, can\'t send UDP action message');
+        return;
+    }
 
     var HOST = '255.255.255.255';
     var message;

--- a/server.js
+++ b/server.js
@@ -622,7 +622,7 @@ hardwareAPI.setup(objects, objectLookup, knownObjects, socketArray, globalVariab
 var utilitiesCallbacks = {
     triggerUDPCallbacks: hardwareAPI.triggerUDPCallbacks
 }
-utilities.setup({realityEditorUpdateSocketArray}, utilitiesCallbacks);
+utilities.setup({realityEditorUpdateSocketArray}, io, utilitiesCallbacks);
 
 nodeUtilities.setup(objects, sceneGraph, knownObjects, socketArray, globalVariables, hardwareAPI, objectsPath, linkController);
 

--- a/server.js
+++ b/server.js
@@ -76,7 +76,7 @@ try {
 }
 
 const _logger = require('./logger');
-const {objectsPath} = require('./config');
+const {objectsPath, SIMULATE_CELLULAR_NETWORK} = require('./config');
 const {providedServices} = require('./services');
 
 const os = require('os');
@@ -1179,6 +1179,11 @@ function objectBeatSender(PORT, thisId, thisIp, oneTimeOnly = false, immediate =
     if (isLightweightMobile) {
         return;
     }
+    
+    if (SIMULATE_CELLULAR_NETWORK) {
+        console.warn('SIMULATE_CELLULAR_NETWORK=true, can\'t send heartbeat');
+        return;
+    }
 
     if (!oneTimeOnly && activeHeartbeats[thisId]) {
         console.log('already created beat for object: ' + thisId);
@@ -1309,7 +1314,10 @@ function objectBeatSender(PORT, thisId, thisIp, oneTimeOnly = false, immediate =
                     zone: zone
                 }));
                 client.send(message, 0, message.length, PORT, HOST, function (err) {
-                    if (err) throw err;
+                    if (err) {
+                        // throw err;
+                        console.warn('error sending one-shot heartbeat', err);
+                    }
                     // close the socket as the function is only called once.
                     client.close();
                 });


### PR DESCRIPTION
If the UDP client.send fails for a heartbeat or action message, tries to send the message to connected clients over an existing websocket.