### PR TITLE
Issue with null value of parent property of human object

### DIFF
--- a/libraries/HumanPoseFuser.js
+++ b/libraries/HumanPoseFuser.js
@@ -282,14 +282,14 @@ class HumanPoseFuser {
             // remove parent reference from its remaining associated human objects
             for (let id of this.humanObjectsOfFusedObject[objectId]) {
                 if (this.objectsRef[id] !== undefined) {
-                    this.objectsRef[id].parent = null;
+                    this.objectsRef[id].parent = 'none';
 
                     this.batchedUpdates[id] = {
                         objectKey: id,
                         frameKey: null,
                         nodeKey: null,
                         propertyPath: 'parent',
-                        newValue: null,
+                        newValue: 'none',
                         editorId: 0
                     };
                 }
@@ -626,7 +626,7 @@ class HumanPoseFuser {
                     if (!proximityMatrix[fi][index]) {
                         // detach the standard object from the fused human object so the pose is not used in subsequent fusion
                         this.humanObjectsOfFusedObject.removeStandardObject(id);
-                        parentValue = null;
+                        parentValue = 'none';
                         unassignedStandardIndices.push(index);
                         if (this.verbose) {
                             console.log('unassigning human obj=' + id + ' from ' + fid);
@@ -657,6 +657,9 @@ class HumanPoseFuser {
             }
 
             if (parentValue !== undefined) {
+                // set new parent reference
+                this.objectsRef[id].parent = parentValue;
+
                 // make entry in batchedUpdates
                 this.batchedUpdates[id] = {
                     objectKey: id,

--- a/libraries/HumanPoseObject.js
+++ b/libraries/HumanPoseObject.js
@@ -52,9 +52,9 @@ function HumanPoseObject(ip, version, protocol, objectId, poseJointSchema) {
     // This is capture timestamp of the image used to compute the pose in the update. Units are miliseconds, but it is a floating-point number with nanosecond precision.
     this.lastUpdateDataTS = 0;
     // Parent is defined when this human object is associated and supports a fused human object (therefore this object does not need to be analyzed/visualized ...)
-    // Parent is 'null' for any fused human object or standalone human object not currently associated with a fused one.
+    // Parent is 'none' for any fused human object or standalone human object not currently associated with a fused one.
     // NOTE: this property can change over time and subscribers to this object should take that into account
-    this.parent = null;
+    this.parent = 'none';
 }
 
 HumanPoseObject.prototype.getName = function(bodyId) {


### PR DESCRIPTION
I noticed issues with auxiliary poses during playback from recorder json. I realised that null value is not supported by recorder. So I changed parent property value from null to 'none' for 'no parent' semantics ().
