### PR TITLE
Always uses direct triggerUDPCallbacks logic; Only calls triggerUDPCallbacks from message handler if a remote message

### DIFF
--- a/server.js
+++ b/server.js
@@ -1373,7 +1373,7 @@ function objectBeatServer() {
         udpServer.close();
     });
 
-    udpServer.on('message', function (msg) {
+    udpServer.on('message', function (msg, rinfo) {
 
         var msgContent;
         // check if object ping
@@ -1413,7 +1413,9 @@ function objectBeatServer() {
             hardwareAPI.triggerMatrixCallbacks(msgContent.matrixBroadcast);
             // }
         } else {
-            hardwareAPI.triggerUDPCallbacks(msgContent);
+            if (rinfo.address !== services.ip) {
+                hardwareAPI.triggerUDPCallbacks(msgContent);
+            }
         }
 
     });


### PR DESCRIPTION
triggerUDPCallbacks from send is lower latency than waiting for a roundtrip and there are some network conditions where a send will successfully complete but not bounce back for the listener to receive.