### PR TITLE
Human tracking updated by children property

### DIFF
--- a/libraries/HumanPoseFuser.js
+++ b/libraries/HumanPoseFuser.js
@@ -548,13 +548,18 @@ class HumanPoseFuser {
 
         // detect change in the subset of associated (child) human objects which currently update their fused object
         const equalArrays = (a, b) => a.length === b.length && a.every((element, index) => element === b[index]);
+
+        // because of recorder limitations this cannot be an empty array. Instead we place 'none' item.
         let arr = [];
         if (selectedObjectId) {
             arr.push(selectedObjectId);
         }
+        else {
+            arr.push('none');
+        }
         if (!equalArrays(arr, this.objectsRef[fusedObjectId].updatedByChildren)) {
             // a change detected, we need to update the property
-            this.objectsRef[fusedObjectId].updatedByChildren = []; //arr;
+            this.objectsRef[fusedObjectId].updatedByChildren = arr;
 
             if (this.batchedUpdates[fusedObjectId] === undefined) {
                 this.batchedUpdates[fusedObjectId] = {};
@@ -802,7 +807,7 @@ class HumanPoseFuser {
                     }
 
                     // add property specific for fused human objects (not defined in standard human objects from apps)
-                    this.objectsRef[fusedObjectId].updatedByChildren = ['none']; // HACK
+                    this.objectsRef[fusedObjectId].updatedByChildren = ['none'];
 
                     if (this.batchedUpdates[fusedObjectId] === undefined) {
                         this.batchedUpdates[fusedObjectId] = {};
@@ -812,7 +817,7 @@ class HumanPoseFuser {
                         frameKey: null,
                         nodeKey: null,
                         propertyPath: 'updatedByChildren',
-                        newValue: [],
+                        newValue: ['none'],
                         editorId: 0
                     };
                 }

--- a/libraries/HumanPoseFuser.js
+++ b/libraries/HumanPoseFuser.js
@@ -59,7 +59,7 @@ class HumanPoseFuser {
      * @param {string} version
      * @param {string} protocol
      * @param {number} beatPort
-     * @param {string} serverUuid 
+     * @param {string} serverUuid
      */
     constructor(objects, sceneGraph, objectLookup, ip, version, protocol, beatPort, serverUuid) {
         // references to global data structures for objects
@@ -147,7 +147,7 @@ class HumanPoseFuser {
 
         /* Configuration parameters */
         /** Verbose logging */
-        this.verbose = true;
+        this.verbose = false;
         /** same frequency as body tracking in Toolbox app */
         this.fuseIntervalMs = 100;
         /** time interval into past to keep in data in pastPoses (on timeline of data ts) */
@@ -553,8 +553,7 @@ class HumanPoseFuser {
         let arr = [];
         if (selectedObjectId) {
             arr.push(selectedObjectId);
-        }
-        else {
+        } else {
             arr.push('none');
         }
         if (!equalArrays(arr, this.objectsRef[fusedObjectId].updatedByChildren)) {

--- a/server.js
+++ b/server.js
@@ -585,7 +585,7 @@ const sceneGraph = new SceneGraph(true);
 const WorldGraph = require('./libraries/sceneGraph/WorldGraph');
 const worldGraph = new WorldGraph(sceneGraph);
 
-const tempUuid = utilities.uuidTime();   // UUID of current run of the server
+const tempUuid = utilities.uuidTime().slice(1);   // UUID of current run of the server  (removed initial underscore)
 
 const HumanPoseFuser = require('./libraries/HumanPoseFuser');
 const humanPoseFuser = new HumanPoseFuser(objects, sceneGraph, objectLookup, services.ip, version, protocol, beatPort, tempUuid);


### PR DESCRIPTION
Added new property 'updatedByChildren' to only fused human objects. This represents a current best human object updating the fused object. It is designed as array because it can be tru fusion of multiple objects (views) in next iteration.
Possible states of the property are: 
undefined  - for standard human objects generated by toolbox apps
['none'] - for fused human objects; no object currently updating fused object  (unlikely but possible scenario)
['\_HUMAN\_**deviceVJ4ubfsh**_pose1__O26kv6p852m']  - for fused human objects; objectId of standard human object which is currently selected.

The bold substring (from editor uuid) should be used to derive which camera/app is currently driving the fused human object. For the standard objects which don't have the property defined , this can be extracted from their objectId. This can be the basis for coloring skeletons in the new lens showing currently active camera.

In Acceleration lens, any change of this property from one pose to another in consecutive timestamps indicates possible artificial 'jump'. So we could choose not to compute/show any acceleration at that point of time.      



