### PR TITLE
If an error occurs during reading hardwareInterface settings, only reset to {} as a default

### DIFF
--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -698,7 +698,9 @@ exports.loadHardwareInterface = function loadHardwareInterface(hardwareInterface
 
     } catch (e) {
         console.log('Could not load settings.json for: ' + hardwareInterfaceName);
-        hardwareInterfaces[hardwareInterfaceName] = {};
+        if (!hardwareInterfaces[hardwareInterfaceName]) {
+            hardwareInterfaces[hardwareInterfaceName] = {};
+        }
     }
 
     this.read = function (settingsName, defaultvalue) {


### PR DESCRIPTION
One of many possible race conditions that may cause the issue where settings on iOS mysteriously reset