### PR TITLE
Add setFull2D API to object.js

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -682,6 +682,7 @@
                 this.setFullScreenOff = makeSendStub('setFullScreenOff');
                 this.setStickyFullScreenOn = makeSendStub('setStickyFullScreenOn');
                 this.setStickinessOff = makeSendStub('setStickinessOff');
+                this.setFull2D = makeSendStub('setFull2D');
                 this.setExclusiveFullScreenOn = makeSendStub('setExclusiveFullScreenOn');
                 this.setExclusiveFullScreenOff = makeSendStub('setExclusiveFullScreenOff');
                 this.isExclusiveFullScreenOccupied = makeSendStub('isExclusiveFullScreenOccupied');
@@ -1383,6 +1384,16 @@
 
             postDataToParent(dataToPost);
         };
+
+        /**
+         * Removes or adds the touch overlay div from the tool, without affecting fullscreen status
+         * @param {boolean} enabled
+         */
+        this.setFull2D = function (enabled) {
+            postDataToParent({
+                full2D: enabled
+            });
+        }
 
         this.setStickyFullScreenOn = function (params) {
             spatialObject.sendFullScreen = 'sticky';


### PR DESCRIPTION
Add API to object.js to allow tools to remove the overlay div covering them, without having to be in fullscreen mode.