### PR TITLE
Add statusCode to local proxy responses

### DIFF
--- a/libraries/serverHelpers/proxyRequestHandler.js
+++ b/libraries/serverHelpers/proxyRequestHandler.js
@@ -7,6 +7,7 @@ const proxyRequestHandler = (req, res) => {
         const headers = req.headers;
         headers.Host = "toolboxedge.net";
         https.get(proxyURL, {headers}, proxyRes => {
+            res.status(proxyRes.statusCode);
             for (let header in proxyRes.headers) {
                 res.setHeader(header, proxyRes.headers[header]);
             }
@@ -19,6 +20,7 @@ const proxyRequestHandler = (req, res) => {
         const queryParams = new URLSearchParams(req.query);
         const url = `${proxyURL}?${queryParams.toString()}`;
         https.get(url, {headers}, proxyRes => {
+            res.status(proxyRes.statusCode);
             for (let header in proxyRes.headers) {
                 res.setHeader(header, proxyRes.headers[header]);
             }


### PR DESCRIPTION
Resolves an issue where chrome would interpret the (incorrect) 200 status code on a partial (206) response as meaning the partial response was a complete response. This correctly forwards the 206 status code in the proxy, fixing the issue with Chrome.