### PR TITLE
adds objectDefaultFiles/styles directory to contain any shared css files

### DIFF
--- a/libraries/objectDefaultFiles/styles/common.css
+++ b/libraries/objectDefaultFiles/styles/common.css
@@ -1,0 +1,13 @@
+.tool-color-gradient {
+    /*animation: tool-color-gradient-anim 0.3s infinite alternate;*/
+    background: linear-gradient(90deg, #000000,#000000, #00ffff, #ee7752, #e73c7e, #23a6d5, #23d5ab,#000000, #000000);
+    background-size: 2000% 200%;
+    animation: gradient 10s infinite;
+    border-radius: 50px;
+}
+
+@keyframes gradient {
+    0% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+    100% { background-position: 0% 50%; }
+}

--- a/server.js
+++ b/server.js
@@ -1550,6 +1550,8 @@ function objectWebServer() {
 
         html = html.replace('objectDefaultFiles/gl-worker.js', level + 'objectDefaultFiles/gl-worker.js');
 
+        html = html.replace('objectDefaultFiles/styles/', level + 'objectDefaultFiles/styles/');
+
         var loadedHtml = cheerio.load(html);
         var scriptNode = '<script src="' + level + 'objectDefaultFiles/object.js"></script>';
         scriptNode += '<script src="' + level + 'objectDefaultFiles/pep.min.js"></script>';


### PR DESCRIPTION
This is a very quick first proposal for where to put shared styles that multiple tools can make use of. Open to suggestions.

Adds a common.css file that for now just contains the tool-color-gradient style for the minimized icon shimmer

Tools can use these files like so: `<link rel="stylesheet" href="objectDefaultFiles/styles/common.css">`
(example: https://github.com/ptcrealitylab/pop-up-onboarding-addon/pull/84)