### PR TITLE
Fix crash due to race condition during target zip upload

### DIFF
--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -279,7 +279,12 @@ exports.getTargetSizeFromTarget = async function getTargetSizeFromTarget(folderN
     }
 
     try {
-        xml2js.Parser().parseString(await fsProm.readFile(xmlFile, 'utf8'), function (err, result) {
+        const contents = await fsProm.readFile(xmlFile, 'utf8');
+        xml2js.Parser().parseString(contents, function (err, result) {
+            if (err) {
+                console.error('error parsing xml', err);
+                return;
+            }
             let first = Object.keys(result)[0];
             let secondFirst = Object.keys(result[first].Tracking[0])[0];
             var sizeString = result[first].Tracking[0][secondFirst][0].$.size;
@@ -293,7 +298,7 @@ exports.getTargetSizeFromTarget = async function getTargetSizeFromTarget(folderN
             };
         });
     } catch (e) {
-        console.warn('error parsing xml, returning default size');
+        console.warn('error parsing xml, returning default size', e);
     }
 
     return resultXML;

--- a/server.js
+++ b/server.js
@@ -2748,7 +2748,11 @@ function objectWebServer() {
                                     }
                                 }
 
-                                await fsProm.rename(folderD + '/' + filename, folderD + '/' + identityFolderName + '/target/target.' + fileExtension);
+                                try {
+                                    await fsProm.rename(folderD + '/' + filename, folderD + '/' + identityFolderName + '/target/target.' + fileExtension);
+                                } catch (e) {
+                                    console.error(`error renaming ${filename} to target.${fileExtension}`, e);
+                                }
 
                                 // Step 1) - resize image if necessary. Vuforia can make targets from jpgs of up to 2048px
                                 // but we scale down to 1024px for a larger margin of error and (even) smaller filesize


### PR DESCRIPTION
Under some conditions the jpg contained in the target zip has already been moved/processed before the call to `rename`