### PR TITLE
Fs prom exists fix

### DIFF
--- a/routers/history.js
+++ b/routers/history.js
@@ -6,13 +6,14 @@ const stream = require('stream');
 const zlib = require('zlib');
 
 const recorder = require('../libraries/recorder.js');
+const {fileExists} = require('../libraries/utilities.js');
 
 const router = express.Router();
 
 let patches = [];
 
 router.get('/logs', async function(req, res) {
-    if (await fsProm.stat(recorder.logsPath).catch(() => false)) { // catch needed because stat throws an error if the file does not exist
+    if (await fileExists(recorder.logsPath)) { // catch needed because stat throws an error if the file does not exist
         try {
             let files = await fsProm.readdir(recorder.logsPath);
             const logNames = {};
@@ -75,7 +76,7 @@ router.get('/logs/:logPath', async function(req, res) {
     }
 
     let compressedLogPath = path.join(recorder.logsPath, req.params.logPath + '.gz');
-    if (!await fsProm.stat(compressedLogPath).catch(() => false)) { // catch needed because stat throws an error if the file does not exist
+    if (!await fileExists(compressedLogPath)) { // catch needed because stat throws an error if the file does not exist
         // Compare only the start `objects_${startTime}` bit of the current log
         // name since the end time is constantly changing
         const startTimeSection = req.params.logPath.split('-')[0];

--- a/routers/history.js
+++ b/routers/history.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const fs = require('fs/promises');
+const fsProm = require('fs/promises');
 const path = require('path');
 const stream = require('stream');
 const zlib = require('zlib');
@@ -11,9 +11,9 @@ const router = express.Router();
 let patches = [];
 
 router.get('/logs', async function(req, res) {
-    if (await fs.exists(recorder.logsPath)) {
+    if (await fsProm.stat(recorder.logsPath).catch(() => false)) { // catch needed because stat throws an error if the file does not exist
         try {
-            let files = await fs.readdir(recorder.logsPath);
+            let files = await fsProm.readdir(recorder.logsPath);
             const logNames = {};
             for (let file of files) {
                 if (file.endsWith('.json.gz')) {
@@ -74,7 +74,7 @@ router.get('/logs/:logPath', async function(req, res) {
     }
 
     let compressedLogPath = path.join(recorder.logsPath, req.params.logPath + '.gz');
-    if (!await fs.exists(compressedLogPath)) {
+    if (!await fsProm.stat(compressedLogPath).catch(() => false)) { // catch needed because stat throws an error if the file does not exist
         // Compare only the start `objects_${startTime}` bit of the current log
         // name since the end time is constantly changing
         const startTimeSection = req.params.logPath.split('-')[0];
@@ -94,7 +94,7 @@ router.get('/logs/:logPath', async function(req, res) {
         return;
     }
 
-    const readStream = fs.createReadStream(compressedLogPath);
+    const readStream = fsProm.createReadStream(compressedLogPath);
     pipeReadStream(req, res, readStream);
 });
 

--- a/routers/history.js
+++ b/routers/history.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const fs = require('fs');
 const fsProm = require('fs/promises');
 const path = require('path');
 const stream = require('stream');
@@ -94,7 +95,7 @@ router.get('/logs/:logPath', async function(req, res) {
         return;
     }
 
-    const readStream = fsProm.createReadStream(compressedLogPath);
+    const readStream = fs.createReadStream(compressedLogPath);
     pipeReadStream(req, res, readStream);
 });
 


### PR DESCRIPTION
Server crashed when loading analytics data from history due to fsProm.exists not...existing. Replaced it with fsProm.stat, which is the recommended way of checking if a file exists. Also ensured createReadStream continues to use old-fashioned `fs`, since fsProm.createReadStream also does not exist.