### PR TITLE
Include the addon name in tool metadata, for use in filtering out core tools from tool menu

### DIFF
--- a/libraries/addons/AddonFramesSource.js
+++ b/libraries/addons/AddonFramesSource.js
@@ -39,12 +39,16 @@ class AddonFramesSource {
         // get a list with the names for all frame types, based on the folder names in the libraries/frames/active folder.
         let frameFolderList = getFolderList(this.frameLibPath);
 
+        // frameLibPath looks like x/y/z/addons/addonName/tools
+        let addonName = path.basename(path.dirname(this.frameLibPath))
+
         // Load the config.js properties of each frame into an object that we can provide to clients upon request.
         for (let i = 0; i < frameFolderList.length; i++) {
             let frameName = frameFolderList[i];
             this.frameTypeModules[frameName] = {
                 properties: {
                     name: frameName,
+                    addon: addonName
                 }
             };
         }

--- a/libraries/addons/AddonFramesSource.js
+++ b/libraries/addons/AddonFramesSource.js
@@ -40,7 +40,7 @@ class AddonFramesSource {
         let frameFolderList = getFolderList(this.frameLibPath);
 
         // frameLibPath looks like x/y/z/addons/addonName/tools
-        let addonName = path.basename(path.dirname(this.frameLibPath))
+        let addonName = path.basename(path.dirname(this.frameLibPath));
 
         // Load the config.js properties of each frame into an object that we can provide to clients upon request.
         for (let i = 0; i < frameFolderList.length; i++) {

--- a/libraries/addons/AddonFramesSource.js
+++ b/libraries/addons/AddonFramesSource.js
@@ -41,10 +41,8 @@ class AddonFramesSource {
 
         // filter out folders that don't have an index.html file (empty folders, etc)
         frameFolderList = frameFolderList.filter(folderName => {
-            let fullPath = path.join(this.frameLibPath, folderName);
-            let contents = fs.readdirSync(fullPath);
-            // console.log(contents);
-            return contents.includes('index.html');
+            let fileList = fs.readdirSync(path.join(this.frameLibPath, folderName));
+            return fileList.includes('index.html');
         });
 
         // frameLibPath looks like x/y/z/addons/addonName/tools

--- a/libraries/addons/AddonFramesSource.js
+++ b/libraries/addons/AddonFramesSource.js
@@ -39,6 +39,14 @@ class AddonFramesSource {
         // get a list with the names for all frame types, based on the folder names in the libraries/frames/active folder.
         let frameFolderList = getFolderList(this.frameLibPath);
 
+        // filter out folders that don't have an index.html file (empty folders, etc)
+        frameFolderList = frameFolderList.filter(folderName => {
+            let fullPath = path.join(this.frameLibPath, folderName);
+            let contents = fs.readdirSync(fullPath);
+            // console.log(contents);
+            return contents.includes('index.html');
+        });
+
         // frameLibPath looks like x/y/z/addons/addonName/tools
         let addonName = path.basename(path.dirname(this.frameLibPath));
 

--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -1843,7 +1843,7 @@
                     }
                 };
             });
-        }
+        };
 
         /**
          * Programmatically opens device keyboard.


### PR DESCRIPTION
The `/availableFrames` API gave a JSON response like:

```
{
  "all-frame-envelope": {
    "properties": {
      "name": "all-frame-envelope",
    },
    "metadata": {
      "enabled": true
    }
  },
  ...
  "communication": {
    "properties": {
      "name": "communication",
    },
    "metadata": {
      "enabled": true
    }
  }, ...
```

Now it gives one like:

```
{
  "all-frame-envelope": {
    "properties": {
      "name": "all-frame-envelope",
      "addon": "vuforia-spatial-core-addon"
    },
    "metadata": {
      "enabled": true
    }
  },
  ...
  "communication": {
    "properties": {
      "name": "communication",
      "addon": "pop-up-onboarding-addon"
    },
    "metadata": {
      "enabled": true
    }
  }, ...
```