### PR TITLE
Prevent cycles from setParent; Fix overwriting worldId of world object

### DIFF
--- a/controllers/object.js
+++ b/controllers/object.js
@@ -210,7 +210,7 @@ const setMatrix = function(objectID, body, callback) {
 
     object.matrix = body.matrix;
 
-    if (typeof body.worldId !== 'undefined' && body.worldId !== object.worldId) {
+    if (typeof body.worldId !== 'undefined' && body.worldId !== object.worldId && !object.isWorldObject) {
         object.worldId = body.worldId;
         sceneGraph.updateObjectWorldId(objectID, object.worldId);
     }

--- a/libraries/sceneGraph/SceneNode.js
+++ b/libraries/sceneGraph/SceneNode.js
@@ -16,6 +16,7 @@ function SceneNode(id) {
     this.children = [];
     this.id = id; // mostly attached for debugging
     this.parent = null;
+    this.visited = false;
 
     // if true, any nodes added to this will instead be added to a child of this rotating 90deg
     this.needsRotateX = false;
@@ -38,6 +39,16 @@ function SceneNode(id) {
 }
 
 /**
+ * Visits all children of this node, setting `visited` to true
+ */
+SceneNode.prototype.visitAllChildren = function() {
+    this.visited = true;
+    for (let child of this.children) {
+        child.visitAllChildren();
+    }
+};
+
+/**
  * Sets the parent node of this node, so that it is positioned relative to that
  * @param {SceneNode} parent
  */
@@ -46,7 +57,10 @@ SceneNode.prototype.setParent = function(parent) {
         return; // ignore duplicate function calls
     }
 
-    if (parent === this) { // TODO: more robustly prevent all cycles in the tree
+    parent.visited = false;
+    this.visitAllChildren();
+    if (parent.visited) {
+        console.error('Attempt to introduce cycle into scene graph', this.id, parent.id, new Error().stack);
         return;
     }
 


### PR DESCRIPTION
Fixes an issue where setParent would introduce a cycle into the scene graph due to treating secondary world objects like children of the first observed world object. Honestly not sure what the correct behavior would be, but I'm at least confident that it's not get stuck recursing forever.