### PR TITLE
Safer logic around fs access and async/await

### DIFF
--- a/controllers/frame.js
+++ b/controllers/frame.js
@@ -1,8 +1,7 @@
-const fsProm = require('fs/promises');
 const path = require('path');
 
 const utilities = require('../libraries/utilities');
-const {fileExists} = utilities;
+const {unlinkIfExists} = utilities;
 const Frame = require('../models/Frame');
 const Node = require('../models/Node');
 
@@ -307,9 +306,7 @@ const deleteFrame = async function(objectId, frameId, body, callback) {
         const videoDir = utilities.getVideoDir(objectName);
         const videoFilePath = path.join(videoDir, urlArray[6]);
 
-        if (await fileExists(videoFilePath)) {
-            await fsProm.unlink(videoFilePath);
-        }
+        await unlinkIfExists(videoFilePath);
     }
 
     const objectName = object.name;

--- a/controllers/logicNode.js
+++ b/controllers/logicNode.js
@@ -1,7 +1,7 @@
 const fsProm = require('fs/promises');
 const formidable = require('formidable');
 const utilities = require('../libraries/utilities');
-const {fileExists} = utilities;
+const {mkdirIfNotExists, unlinkIfExists} = utilities;
 const EdgeBlock = require('../models/EdgeBlock');
 
 // Variables populated from server.js with setup()
@@ -173,9 +173,8 @@ function uploadIconImage(objectID, frameID, nodeID, req, callback) {
         }
 
         var iconDir = objectsPath + '/' + object.name + '/' + identityFolderName + '/logicNodeIcons';
-        if (!await fileExists(iconDir)) {
-            await fsProm.mkdir(iconDir);
-        }
+
+        await mkdirIfNotExists(iconDir);
 
         var form = new formidable.IncomingForm({
             uploadDir: iconDir,
@@ -190,9 +189,7 @@ function uploadIconImage(objectID, frameID, nodeID, req, callback) {
 
         var rawFilepath = form.uploadDir + '/' + nodeID + '_fullSize.jpg';
 
-        if (await fileExists(rawFilepath)) {
-            await fsProm.unlink(rawFilepath);
-        }
+        await unlinkIfExists(rawFilepath);
 
         form.on('fileBegin', function (name, file) {
             file.path = rawFilepath;
@@ -205,9 +202,7 @@ function uploadIconImage(objectID, frameID, nodeID, req, callback) {
 
             var resizedFilepath = form.uploadDir + '/' + nodeID + '.jpg';
 
-            if (await fileExists(resizedFilepath)) {
-                await fsProm.unlink(resizedFilepath);
-            }
+            await unlinkIfExists(resizedFilepath);
 
             // copied fullsize file into resized image file as backup, in case resize operation fails
             await fsProm.copyFile(rawFilepath, resizedFilepath);

--- a/controllers/object.js
+++ b/controllers/object.js
@@ -2,7 +2,7 @@ const fsProm = require('fs/promises');
 const path = require('path');
 const formidable = require('formidable');
 const utilities = require('../libraries/utilities');
-const {fileExists} = utilities;
+const {fileExists, unlinkIfExists, mkdirIfNotExists} = utilities;
 
 // Variables populated from server.js with setup()
 var objects = {};
@@ -72,9 +72,7 @@ const uploadVideo = async function(objectID, videoID, reqForForm, callback) {
 
         var rawFilepath = form.uploadDir + '/' + videoID + '.mp4';
 
-        if (await fileExists(rawFilepath)) {
-            await fsProm.unlink(rawFilepath);
-        }
+        await unlinkIfExists(rawFilepath);
 
         form.on('fileBegin', function (name, file) {
             file.path = rawFilepath;
@@ -123,9 +121,7 @@ async function uploadMediaFile(objectID, req, callback) {
     }
 
     let mediaDir = objectsPath + '/' + object.name + '/' + identityFolderName + '/mediaFiles';
-    if (!await fileExists(mediaDir)) {
-        await fsProm.mkdir(mediaDir);
-    }
+    await mkdirIfNotExists(mediaDir);
 
     let form = new formidable.IncomingForm({
         uploadDir: mediaDir,
@@ -149,9 +145,7 @@ async function uploadMediaFile(objectID, req, callback) {
 
         // Rename the file after it's been saved
         try {
-            if (await fileExists(newFilepath)) {
-                await fsProm.unlink(newFilepath);
-            }
+            await unlinkIfExists(newFilepath);
             let currentPath = file.path ? file.path : file.filepath;
             await fsProm.rename(currentPath, newFilepath);
             console.log(`File renamed from ${currentPath} to ${newFilepath}`);
@@ -245,9 +239,7 @@ const memoryUpload = async function(objectID, req, callback) {
     }
 
     var memoryDir = objectsPath + '/' + obj.name + '/' + identityFolderName + '/memory/';
-    if (!await fileExists(memoryDir)) {
-        await fsProm.mkdir(memoryDir);
-    }
+    await mkdirIfNotExists(memoryDir);
 
     var form = new formidable.IncomingForm({
         uploadDir: memoryDir,
@@ -351,9 +343,7 @@ const generateXml = async function(objectID, body, callback) {
         '   </ARConfig>';
 
     let targetDir = path.join(objectsPath, objectName, identityFolderName, 'target');
-    if (!await fileExists(targetDir)) {
-        await fsProm.mkdir(targetDir);
-    }
+    await mkdirIfNotExists(targetDir);
 
     var xmlOutFile = path.join(targetDir, 'target.xml');
 

--- a/libraries/nodeUtilities.js
+++ b/libraries/nodeUtilities.js
@@ -19,6 +19,10 @@ exports.searchNodeByType = async function (nodeType, objectKey, tool, node, call
         thisObjectKey = await utilities.getObjectIdFromTargetOrObjectFile(objectKey);
     }
     let thisObject = utilities.getObject(objects, thisObjectKey);
+    if (!thisObject) {
+        console.error('searchNodeByType object not found');
+        return;
+    }
     if (!tool && !node) {
         utilities.forEachFrameInObject(thisObject, function (thisTool, toolKey) {
             utilities.forEachNodeInFrame(thisTool, function (thisNode, nodeKey) {

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -131,7 +131,7 @@ exports.createFrameFolder = async function (folderVar, frameVar, dirnameO, locat
  * Recursively delete a folder and its contents
  * @param {string} folder - path to folder
  */
-async function deleteFolderRecursive(folder) {
+async function rmdirIfExists(folder) {
     if (!await fileExists(folder)) {
         console.warn(`folder ${folder} is already not present`);
         return;
@@ -139,10 +139,10 @@ async function deleteFolderRecursive(folder) {
     try {
         await fsProm.rmdir(folder, {recursive: true});
     } catch (err) {
-        console.error('deleteFolderRecursive fs race', err);
+        console.error('rmdirIfExists fs race', err);
     }
 }
-exports.deleteFolderRecursive = deleteFolderRecursive;
+exports.rmdirIfExists = rmdirIfExists;
 
 /**
  * Deletes a directory from the hierarchy. Intentionally limited to frames so that you don't delete something more important.
@@ -161,7 +161,7 @@ exports.deleteFrameFolder = async function (objectName, frameName) {
     });
 
     if (isDeletableFrame) {
-        await deleteFolderRecursive(folderPath);
+        await rmdirIfExists(folderPath);
     }
 };
 
@@ -598,7 +598,7 @@ exports.updateObject = async function updateObject(objectName, objects) {
 
 exports.deleteObject = async function deleteObject(objectName, objects, objectLookup, _activeHeartbeats, knownObjects, sceneGraph, setAnchors) {
     let objectFolderPath = path.join(objectsPath, objectName);
-    await deleteFolderRecursive(objectFolderPath);
+    await rmdirIfExists(objectFolderPath);
 
     let objectKey = readObject(objectLookup, objectName);
 

--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -117,8 +117,15 @@ exports.printFolder = async function printFolder(objects, objectsPath, _debug, o
 
     // populate the data for each object template on the frontend, using data from each directory found in the spatialToolbox directory
     for (const objectKey of objectFolderList) {
-        var thisObjectKey = objectKey;
-        var tempKey = await utilities.getObjectIdFromTargetOrObjectFile(objectKey); // gets the object id from the xml target file
+        let thisObjectKey = objectKey;
+        let tempKey;
+        try {
+            // gets the object id from the xml target file
+            tempKey = await utilities.getObjectIdFromTargetOrObjectFile(objectKey);
+        } catch (e) {
+            console.warn('printFolder getObjectId failed', e);
+        }
+
         if (tempKey) {
             thisObjectKey = tempKey;
         }

--- a/server.js
+++ b/server.js
@@ -343,7 +343,7 @@ if (!isLightweightMobile) {
 
 // This file hosts all kinds of utilities programmed for the server
 const utilities = require('./libraries/utilities');
-const {fileExists, mkdirIfNotExists, unlinkIfExists} = utilities;
+const {fileExists, mkdirIfNotExists, rmdirIfExists, unlinkIfExists} = utilities;
 const nodeUtilities = require('./libraries/nodeUtilities');
 const recorder = require('./libraries/recorder');
 
@@ -2347,9 +2347,9 @@ function objectWebServer() {
                 try {
                     const folderStats = await fsProm.stat(folderDel);
                     if (folderStats.isDirectory()) {
-                        await utilities.deleteFolderRecursive(folderDel);
+                        await rmdirIfExists(folderDel);
                     } else {
-                        await fsProm.unlink(folderDel);
+                        await unlinkIfExists(folderDel);
                     }
                 } catch (_e) {
                     console.warn('contentDelete frame path already deleted', folderDel);
@@ -2378,9 +2378,9 @@ function objectWebServer() {
                     const folderStats = await fsProm.stat(folderDel);
 
                     if (folderStats.isDirectory()) {
-                        await utilities.deleteFolderRecursive(folderDel);
+                        await rmdirIfExists(folderDel);
                     } else {
-                        await fsProm.unlink(folderDel);
+                        await unlinkIfExists(folderDel);
                     }
                 } catch (_e) {
                     console.warn('contentDelete path already deleted', folderDel);
@@ -2585,7 +2585,7 @@ function objectWebServer() {
 
                     var folderDelFrame = objectsPath + '/' + req.body.name + '/' + frameName;
 
-                    await utilities.deleteFolderRecursive(folderDelFrame);
+                    await rmdirIfExists(folderDelFrame);
 
                     if (objectKey !== null && frameNameKey !== null) {
                         if (thisObject) {
@@ -2609,7 +2609,7 @@ function objectWebServer() {
                 } else {
 
                     const folderDel = objectsPath + '/' + req.body.name;
-                    await utilities.deleteFolderRecursive(folderDel);
+                    await rmdirIfExists(folderDel);
 
                     var tempFolderName2 = utilities.readObject(objectLookup, req.body.name);
 
@@ -2736,9 +2736,9 @@ function objectWebServer() {
                     if (await fileExists(folderDel)) {
                         try {
                             if ((await fsProm.stat(folderDel)).isDirectory()) {
-                                await utilities.deleteFolderRecursive(folderDel);
+                                await rmdirIfExists(folderDel);
                             } else {
-                                await fsProm.unlink(folderDel);
+                                await unlinkIfExists(folderDel);
                             }
                         } catch (e) {
                             console.warn(`Unable to unlink '${folderDel}'`, e);


### PR DESCRIPTION
Various calls can throw exceptions if e.g. trying to delete a file which
already doesn't exist, so this wraps all patterns where condition is
checked -> condition is acted on with exception handlers for the case
where the condition changes during function execution. Introduces
mkdirIfNotExists and unlinkIfExists for this purpose

Tries to identify places where changes in a global variable (`objects`,
it's always `objects`) could happen during the execution of an async
function and break preconditions (usually the deletion of objects[key]).
Also wraps some potentially problematic calls to fs apis that could
throw.