### PR TITLE
Adds targetId to object.json; loosens restriction that ID from target.xml must match the objectID

### DIFF
--- a/libraries/hardwareInterfaces.js
+++ b/libraries/hardwareInterfaces.js
@@ -734,7 +734,7 @@ exports.hasTool = function(object, tool) {
 };
 
 exports.getObjectIdFromObjectName = async function (object) {
-    return await utilities.getObjectIdFromTargetOrObjectFile(object);
+    return await utilities.getObjectIdFromObjectFile(object);
 };
 
 exports.getObjectNameFromObjectId = function (objectId) {

--- a/libraries/nodeUtilities.js
+++ b/libraries/nodeUtilities.js
@@ -16,7 +16,7 @@ exports.deepCopy = utilities.deepCopy;
 exports.searchNodeByType = async function (nodeType, objectKey, tool, node, callback) {
     let thisObjectKey = objectKey;
     if (!(objectKey in objects)) {
-        thisObjectKey = await utilities.getObjectIdFromTargetOrObjectFile(objectKey);
+        thisObjectKey = await utilities.getObjectIdFromObjectFile(objectKey);
     }
     let thisObject = utilities.getObject(objects, thisObjectKey);
     if (!thisObject) {

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -63,6 +63,7 @@ const dgram = require('dgram'); // UDP Broadcasting library
 const path = require('path');
 const request = require('request');
 const fetch = require('node-fetch');
+const DecompressZip = require('decompress-zip');
 const ObjectModel = require('../models/ObjectModel.js');
 const {objectsPath, beatPort} = require('../config.js');
 const {isLightweightMobile} = require('../isMobile.js');
@@ -253,6 +254,98 @@ async function getAnchorIdFromObjectFile(folderName) {
     return null;
 }
 exports.getAnchorIdFromObjectFile = getAnchorIdFromObjectFile;
+
+exports.getTargetIdFromTargetDat = async function getTargetIdFromTargetDat(targetFolderPath) {
+    return new Promise((resolve, reject) => {
+        // deferred = true;
+        // unzip the .dat file and read the unique targetId from the config.info file
+        let unzipperDat = new DecompressZip(path.join(targetFolderPath, 'target.dat'));
+
+        unzipperDat.on('error', function (err) {
+            console.error('.dat Unzipper Error', err);
+            reject(err);
+        });
+
+        unzipperDat.on('extract', async function () {
+            // finish();
+            console.log('.dat Unzipper finished');
+
+            let configFilePath = path.join(targetFolderPath, 'config.info');
+            if (await fileExists(configFilePath)) {
+                // try to read the config.info file as text
+                let targetUniqueId = await getTargetIdFromFile(configFilePath);
+                console.log('targetUniqueId = ', targetUniqueId);
+                resolve(targetUniqueId);
+            } else {
+                // console.log('config.info not found at ', configFilePath);
+                reject('config.info not found at ' + configFilePath)
+            }
+        });
+
+        unzipperDat.on('progress', function (_fileIndex, _fileCount) {
+            // console.log('Extracted 3dt file ' + (fileIndex + 1) + ' of ' + fileCount);
+        });
+
+        unzipperDat.extract({
+            path: targetFolderPath,
+            filter: function (file) {
+                // skipping over frame_%d.jpg, images.json, and tileset.json
+                // return file.type !== 'SymbolicLink' && file.filename.endsWith('glb');
+                return file.type !== 'SymbolicLink' && file.filename.endsWith('info');
+            }
+        });
+    });
+}
+
+async function getTargetIdFromFile(filePath) {
+    if (!await fileExists(filePath)) {
+        return null;
+    }
+
+    let contents;
+    try {
+        contents = await fsProm.readFile(filePath, 'utf8');
+    } catch (err) {
+        console.error('Unable to read xml file for target ID', err);
+        return null;
+    }
+
+    let resultId = null;
+
+    xml2js.Parser().parseString(contents, function (parseErr, result) {
+        try {
+            if (parseErr) {
+                throw parseErr;
+            }
+
+            console.log(result);
+            // this gets the "AreaTarget" or "ImageTarget" tag contents of the XML file
+            let targetEntry = Object.entries(result.QCARInfo.TargetSet[0]).find(entry => entry[0] !== '$');
+            // this extracts the properties associated with that tag in the file, e.g. { version: "5.1", bbox: "...", targetId: "xzy": name: "_WORLD_test_xyz" }
+            let targetMetadata = targetEntry[1][0].$;
+            resultId = targetMetadata.targetId;
+
+            // let first = Object.keys(result)[0];
+            // let secondFirst = Object.keys(result[first].Tracking[0])[0];
+            // var sizeString = result[first].Tracking[0][secondFirst][0].$.size;
+            // if (!sizeString) {
+            //     return;
+            // }
+            // var sizeFloatArray = sizeString.split(' ').map(function (elt) {
+            //     // TODO: this assumption makes it backwards compatible but might cause problems in the future
+            //     return (parseFloat(elt) < 10) ? parseFloat(elt) : 0.001 * parseFloat(elt); // detect meter or mm scale
+            // });
+            // resultXML = {
+            //     width: sizeFloatArray[0],
+            //     height: sizeFloatArray[1]
+            // };
+        } catch (err) {
+            console.error('error parsing xml', err);
+        }
+    });
+
+    return resultId;
+}
 
 /**
  *

--- a/libraries/utilities.js
+++ b/libraries/utilities.js
@@ -186,38 +186,15 @@ exports.uuidTime = function () {
     return '_' + stampUuidTime;
 };
 
-async function getObjectIdFromTargetOrObjectFile(folderName) {
+async function getObjectIdFromObjectFile(folderName) {
 
     if (folderName === 'allTargetsPlaceholder') {
         return 'allTargetsPlaceholder000000000000';
     }
 
-    var xmlFile = objectsPath + '/' + folderName + '/' + identityFolderName + '/target/target.xml';
-    var jsonFile = objectsPath + '/' + folderName + '/' + identityFolderName + '/object.json';
+    let jsonFile = objectsPath + '/' + folderName + '/' + identityFolderName + '/object.json';
 
-    if (await fileExists(xmlFile)) {
-        try {
-            let resultXML = '';
-            xml2js.Parser().parseString(await fsProm.readFile(xmlFile, 'utf8'),
-                function (err, result) {
-                    for (var first in result) {
-                        for (var secondFirst in result[first].Tracking[0]) {
-                            resultXML = result[first].Tracking[0][secondFirst][0].$.name;
-                            if (typeof resultXML === 'string' && resultXML.length === 0) {
-                                console.warn('Target file for ' + folderName + ' has empty name, ' +
-                                    'and may not function correctly. Delete and re-upload target for best results.');
-                                resultXML = null;
-                            }
-                            break;
-                        }
-                        break;
-                    }
-                });
-            return resultXML;
-        } catch (e) {
-            console.error('error reading xml file', e);
-        }
-    } else if (await fileExists(jsonFile)) {
+    if (await fileExists(jsonFile)) {
         try {
             let thisObject = JSON.parse(await fsProm.readFile(jsonFile, 'utf8'));
             if (thisObject.hasOwnProperty('objectId')) {
@@ -231,7 +208,7 @@ async function getObjectIdFromTargetOrObjectFile(folderName) {
     }
     return null;
 }
-exports.getObjectIdFromTargetOrObjectFile = getObjectIdFromTargetOrObjectFile;
+exports.getObjectIdFromObjectFile = getObjectIdFromObjectFile;
 
 async function getAnchorIdFromObjectFile(folderName) {
 
@@ -275,6 +252,7 @@ exports.getTargetIdFromTargetDat = async function getTargetIdFromTargetDat(targe
                 // try to read the config.info file as text
                 let targetUniqueId = await getTargetIdFromFile(configFilePath);
                 console.log('targetUniqueId = ', targetUniqueId);
+                console.log('TODO: cleanup config.info file instead of leaving it in the folder');
                 resolve(targetUniqueId);
             } else {
                 // console.log('config.info not found at ', configFilePath);
@@ -624,7 +602,7 @@ exports.updateObject = async function updateObject(objectName, objects) {
     var objectFolderList = await getObjectFolderList();
 
     for (const objectFolder of objectFolderList) {
-        const tempFolderName = await getObjectIdFromTargetOrObjectFile(objectFolder);
+        const tempFolderName = await getObjectIdFromObjectFile(objectFolder);
 
         if (!tempFolderName) {
             console.warn(' object ' + objectFolder + ' has no marker yet');

--- a/libraries/webFrontend.js
+++ b/libraries/webFrontend.js
@@ -121,7 +121,7 @@ exports.printFolder = async function printFolder(objects, objectsPath, _debug, o
         let tempKey;
         try {
             // gets the object id from the xml target file
-            tempKey = await utilities.getObjectIdFromTargetOrObjectFile(objectKey);
+            tempKey = await utilities.getObjectIdFromObjectFile(objectKey);
         } catch (e) {
             console.warn('printFolder getObjectId failed', e);
         }

--- a/models/ObjectModel.js
+++ b/models/ObjectModel.js
@@ -15,6 +15,8 @@ function ObjectModel(ip, version, protocol, objectId) {
     this.objectId = objectId;
     // The name for the object used for interfaces.
     this.name = '';
+    // The UUID used internally by Vuforia for tracking
+    this.targetId = null;
 
     this.matrix = [];
     this.worldId = null; // matrix is relative to this world

--- a/server.js
+++ b/server.js
@@ -3072,43 +3072,6 @@ function objectWebServer() {
                                                             }
                                                         });
                                                     }
-                                                    
-                                                    // if (innerFolderFile === 'target.dat') {
-                                                    //     // deferred = true;
-                                                    //     // unzip the .dat file and read the unique targetId from the config.info file
-                                                    //     let unzipperDat = new DecompressZip(path.join(targetFolderPath, 'target.dat'));
-                                                    //
-                                                    //     unzipperDat.on('error', function (err) {
-                                                    //         console.error('.dat Unzipper Error', err);
-                                                    //     });
-                                                    //
-                                                    //     unzipperDat.on('extract', async function () {
-                                                    //         // finish();
-                                                    //         console.log('.dat Unzipper finished');
-                                                    //        
-                                                    //         let configFilePath = path.join(targetFolderPath, 'config.info');
-                                                    //         if (await fileExists(configFilePath)) {
-                                                    //             // try to read the config.info file as text
-                                                    //             var targetUniqueId = await utilities.getTargetIdFromFile(configFilePath);
-                                                    //             console.log('targetUniqueId = ', targetUniqueId);
-                                                    //         } else {
-                                                    //             console.log('config.info not found at ', configFilePath);
-                                                    //         }
-                                                    //     });
-                                                    //
-                                                    //     unzipperDat.on('progress', function (_fileIndex, _fileCount) {
-                                                    //         // console.log('Extracted 3dt file ' + (fileIndex + 1) + ' of ' + fileCount);
-                                                    //     });
-                                                    //
-                                                    //     unzipperDat.extract({
-                                                    //         path: targetFolderPath,
-                                                    //         filter: function (file) {
-                                                    //             // skipping over frame_%d.jpg, images.json, and tileset.json
-                                                    //             // return file.type !== 'SymbolicLink' && file.filename.endsWith('glb');
-                                                    //             return file.type !== 'SymbolicLink' && file.filename.endsWith('info');
-                                                    //         }
-                                                    //     });
-                                                    // }
                                                 }
                                                 if (!deferred) {
                                                     finish();

--- a/server.js
+++ b/server.js
@@ -3069,6 +3069,43 @@ function objectWebServer() {
                                                             }
                                                         });
                                                     }
+                                                    
+                                                    // if (innerFolderFile === 'target.dat') {
+                                                    //     // deferred = true;
+                                                    //     // unzip the .dat file and read the unique targetId from the config.info file
+                                                    //     let unzipperDat = new DecompressZip(path.join(targetFolderPath, 'target.dat'));
+                                                    //
+                                                    //     unzipperDat.on('error', function (err) {
+                                                    //         console.error('.dat Unzipper Error', err);
+                                                    //     });
+                                                    //
+                                                    //     unzipperDat.on('extract', async function () {
+                                                    //         // finish();
+                                                    //         console.log('.dat Unzipper finished');
+                                                    //        
+                                                    //         let configFilePath = path.join(targetFolderPath, 'config.info');
+                                                    //         if (await fileExists(configFilePath)) {
+                                                    //             // try to read the config.info file as text
+                                                    //             var targetUniqueId = await utilities.getTargetIdFromFile(configFilePath);
+                                                    //             console.log('targetUniqueId = ', targetUniqueId);
+                                                    //         } else {
+                                                    //             console.log('config.info not found at ', configFilePath);
+                                                    //         }
+                                                    //     });
+                                                    //
+                                                    //     unzipperDat.on('progress', function (_fileIndex, _fileCount) {
+                                                    //         // console.log('Extracted 3dt file ' + (fileIndex + 1) + ' of ' + fileCount);
+                                                    //     });
+                                                    //
+                                                    //     unzipperDat.extract({
+                                                    //         path: targetFolderPath,
+                                                    //         filter: function (file) {
+                                                    //             // skipping over frame_%d.jpg, images.json, and tileset.json
+                                                    //             // return file.type !== 'SymbolicLink' && file.filename.endsWith('glb');
+                                                    //             return file.type !== 'SymbolicLink' && file.filename.endsWith('info');
+                                                    //         }
+                                                    //     });
+                                                    // }
                                                 }
                                                 if (!deferred) {
                                                     finish();
@@ -3238,10 +3275,13 @@ async function createObjectFromTarget(folderVar) {
         return;
     }
 
+    let targetUniqueId = await utilities.getTargetIdFromTargetDat(path.join(objectsPath, folderVar, identityFolderName, 'target'));
+
     objects[objectIDXML] = new ObjectModel(services.ip, version, protocol, objectIDXML);
     objects[objectIDXML].port = serverPort;
     objects[objectIDXML].name = folderVar;
     objects[objectIDXML].targetSize = objectSizeXML;
+    objects[objectIDXML].targetId = targetUniqueId;
 
     if (objectIDXML.indexOf(worldObjectName) > -1) { // TODO: implement a more robust way to tell if it's a world object
         objects[objectIDXML].isWorldObject = true;


### PR DESCRIPTION
`targetId` is extracted from the target.dat file by unzipping target.dat and parsing the contained config.info file.

Goes with https://github.com/ptcrealitylab/vuforia-spatial-toolbox-ios-swift/pull/555