### PR TITLE
configure winston to ignore spammy decompress-zip warnings

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -40,7 +40,15 @@ const colorizedFormat = format.combine(
 
 const logger = createLogger({
     level: process.env.LOG_LEVEL || 'debug',
-    format: isMobile ? monochromeFormat : colorizedFormat,
+    format: winston.format.combine(
+        isMobile ? monochromeFormat : colorizedFormat,
+        winston.format(info => {
+            if (info.message.includes('Possibly unsupported ZIP platform type')) {
+                return false; // Ignore logs from decompress-zip structures.js when decompressing target.dat
+            }
+            return info;
+        })()
+    ),
     transports: [new transports.Console()]
 });
 


### PR DESCRIPTION
Not sure if there's a better approach for this, but currently I'm getting hundreds of warning lines from the decompress-zip library every time I use it to decompress the target.dat (which I do on server restart to ensure the file didn't change while the server was off), like:

```
2024-01-12T20:03:10.652Z - warn: Possibly unsupported ZIP platform type, 19 
2024-01-12T20:03:10.652Z - warn: Possibly unsupported ZIP platform type, 19 
2024-01-12T20:03:10.652Z - warn: Possibly unsupported ZIP platform type, 19 
...
2024-01-12T20:03:10.652Z - warn: Possibly unsupported ZIP platform type, 19
```
This seems to work for suppressing those messages.
