### PR TITLE
Mobile wrapping and no exit

### DIFF
--- a/index-nofork.js
+++ b/index-nofork.js
@@ -4,8 +4,13 @@ process.on('uncaughtException', (e) => {
     console.error('Uncaught server error', e);
 });
 
-try {
-    const _ = require('./server.js');
-} catch (e) {
-    console.error('Fatal server error', e);
+function run() {
+    try {
+        const _ = require('./server.js');
+    } catch (e) {
+        console.error('Fatal server error', e);
+        setTimeout(run, 1000);
+    }
 }
+
+run();

--- a/index-nofork.js
+++ b/index-nofork.js
@@ -1,0 +1,11 @@
+const process = require('process');
+
+process.on('uncaughtException', (e) => {
+    console.error('Uncaught server error', e);
+});
+
+try {
+    const _ = require('./server.js');
+} catch (e) {
+    console.error('Fatal server error', e);
+}

--- a/server.js
+++ b/server.js
@@ -1153,7 +1153,7 @@ async function exit() {
     staleObjectCleaner.clearCleanupIntervals();
     humanPoseFuser.stop();
     console.info('Server exited successfully');
-    if (process.env.NODE_ENV !== 'test') {
+    if (process.env.NODE_ENV !== 'test' && !globalVariables.isMobile) {
         process.exit(0);
     }
 }


### PR DESCRIPTION
Following this, the iOS app can invoke index-nofork for a guaranteed* error free experience

*not enforceable in a court of law