### PR TITLE
New tools now initialize properly on slow networks

### DIFF
--- a/libraries/objectDefaultFiles/object.js
+++ b/libraries/objectDefaultFiles/object.js
@@ -909,20 +909,22 @@
          * Subscribes this socket to data values being written to nodes on this frame
          */
         this.sendRealityEditorSubscribe = function () {
-            var timeoutFunction = function() {
-                if (spatialObject.object) {
-                    self.ioObject.emit(getIoTitle('/subscribe/realityEditor'), JSON.stringify({
-                        object: spatialObject.object,
-                        frame: spatialObject.frame,
-                        protocol: spatialObject.protocol
-                    }));
+            let timeout = 10;
+            function subscribe() {
+                if (self.ioObject.socket.readyState !== self.ioObject.socket.OPEN) {
+                    if (timeout < 1000) {
+                        timeout *= 10;
+                    }
+                    setTimeout(subscribe, timeout);
+                    return;
                 }
-            };
-            // Call it a few times to help ensure it succeeds
-            setTimeout(timeoutFunction, 10);
-            setTimeout(timeoutFunction, 50);
-            setTimeout(timeoutFunction, 100);
-            setTimeout(timeoutFunction, 1000);
+                self.ioObject.emit(getIoTitle('/subscribe/realityEditor'), JSON.stringify({
+                    object: spatialObject.object,
+                    frame: spatialObject.frame,
+                    protocol: spatialObject.protocol
+                }));
+            }
+            subscribe();
         };
         this.sendRealityEditorSubscribe();
 


### PR DESCRIPTION
New tools now initialize properly on slow networks, previous method sent subscribe method before socket was ready, resulting in no subscription being created.

This fixes the following bugs:
• On slow networks, placing a tool fails to load the tool, despite creating it on the server
• On slow networks, new tools added by other users fail to subscribe to publicData messages, and can only write, not read updates

To reproduce said network conditions, set network speed to Slow 3G in Chrome's network pane, Fast 3G reproduces these bugs only sometimes.